### PR TITLE
マニュフェストv3への対応

### DIFF
--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -6,14 +6,52 @@ importScripts("js/zlib.js");
 importScripts("js/zlib-deflate.js");
 importScripts("js/zlib-inflate.js");
 
-(function () {
-    // contextMenusに関する操作
-    chrome.contextMenus.removeAll();
+chrome.runtime.onInstalled.addListener(function () {
+    const parentId = "syncTabClipper-ContextMenu01"
+    const openMenuId = "syncTabClipper-OpenNew-tab"
 
-    //親メニュー
-    const parentId = chrome.contextMenus.create({
-        "title": "syncTabClipper",
+
+    chrome.contextMenus.create({
+        id: parentId,
+        title: "syncTabClipper",
+        type: "normal",
+        contexts: ["all"],
+    });
+
+    chrome.contextMenus.create({
+        id: openMenuId,
+        title: "tabページを開く",
+        parentId: parentId,
+        type: "normal",
+        contexts: ["all"],
+    });
+})
+
+chrome.contextMenus.onClicked.addListener(function (info, tab): void {
+    // https://github.com/STRockefeller/MyProgrammingNote/blob/d985df2a7b4cbae0c3b2e4425292c377e429fcdb/My%20Notes/%E7%A8%8B%E5%BC%8F%E5%AD%B8%E7%BF%92%E7%AD%86%E8%A8%98/Web/Chrome%20Extension/Manifest%20Version%203.md#background-service-workers
+    switch (info.menuItemId) {
+        case "syncTabClipper-OpenNew-tab":
+            // https://gist.github.com/syoichi/3747507
+            const url = chrome.runtime.getURL('tabs.html');
+            console.log(url)
+            /*
+            chrome.tabs.create({
+                selected: true,
+                url: url
+            });
+             */
+            break;
+    }
+});
+
+
+/*
+chrome.runtime.onInstalled.addListener(function () {
+    const parentId = "syncTabClipper-ContextMenu01"
+    chrome.contextMenus.create({
+        "id": parentId,
         "type": "normal",
+        "title": "syncTabClipper",
         "contexts": ["all"],
     });
 
@@ -31,7 +69,7 @@ importScripts("js/zlib-inflate.js");
             });
         }
     });
-}());
+});
 
 chrome.action.onClicked.addListener(function () {
     chrome.storage.sync.get([util.getTabLengthKey()], function (result) {
@@ -70,3 +108,4 @@ chrome.action.onClicked.addListener(function () {
         });
     });
 });
+*/

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -1,6 +1,11 @@
 import * as util from './util';
 import {blockService} from "./blockService";
 
+//  manifest_version3から複数ファイルのbackground.scripts指定ができなくなったので、直接importする
+importScripts("js/zlib.js");
+importScripts("js/zlib-deflate.js");
+importScripts("js/zlib-inflate.js");
+
 (function () {
     // contextMenusに関する操作
     chrome.contextMenus.removeAll();
@@ -28,7 +33,7 @@ import {blockService} from "./blockService";
     });
 }());
 
-chrome.browserAction.onClicked.addListener(function () {
+chrome.action.onClicked.addListener(function () {
     chrome.storage.sync.get([util.getTabLengthKey()], function (result) {
         const tab_length = util.getTabLengthOrZero(result);
         chrome.tabs.query({currentWindow: true}, function (tabs: chrome.tabs.Tab[]) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "SyncTabClipper",
   "version": "0.1.1",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "開いているタブを1つにまとめて、メモリ消費を抑えます。アカウントごとにデータは同期して複数端末で同じ記録を使えます。",
   "permissions": [
     "tabs",
@@ -9,13 +9,7 @@
     "contextMenus"
   ],
   "background": {
-    "scripts": [
-      "js/zlib.js",
-      "js/zlib-deflate.js",
-      "js/zlib-inflate.js",
-      "js/background.js"
-    ],
-    "persistant": false
+    "service_worker": "background.js"
   },
   "icons": {
     "16": "images/icon16.png",
@@ -23,7 +17,7 @@
     "48": "images/icon48.png",
     "128": "images/icon128.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": {
       "16": "images/icon16.png"
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,6 +17,13 @@
     "48": "images/icon48.png",
     "128": "images/icon128.png"
   },
+  "web_accessible_resources": [
+    {
+      "resources": [ "tabs.html", "test2.png" ],
+      "extensions": "*"
+    }
+  ],
+
   "action": {
     "default_icon": {
       "16": "images/icon16.png"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,7 +7,7 @@ module.exports = {
         tabs: path.join(__dirname, "src/js/tabs.ts"),
     },
     output: {
-        path: path.join(__dirname, "dist/js"),
+        path: path.join(__dirname, "dist/"),
         filename: "[name].js",
     },
     module: {


### PR DESCRIPTION
chrome extensions Manifest V3への対応

まだ、エラーが残っているので、draft

### 関連資料
- https://stackoverflow.com/a/66437283
- https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/
- https://blog.htmlhifive.com/2018/12/08/service-worker-importscripts/
- https://blog.holyblue.jp/entry/2021/05/03/105010
- https://qiita.com/TiggeZaki/items/bb35afe43c347d38dc4e
- https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/