### PR TITLE
contextMenuに関する処理を切り出し & V3向けの書き方に修正

### DIFF
--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -2,22 +2,9 @@ import {blockService} from "./blockService";
 import {chromeService} from "./chromeService";
 
 (() => {
-  // contextMenusに関する操作
-  chrome.contextMenus.removeAll();
-
-  //親メニュー
-  const parentId = chrome.contextMenus.create({
-    "title": "syncTabClipper",
-    "type": "normal",
-    "contexts": ["all"],
-  });
-
-  chrome.contextMenus.create({
-    "title": "tabページを開く",
-    "parentId": parentId,
-    "type": "normal",
-    "contexts": ["all"],
-    "onclick": chromeService.tab.createTabsPageTab
+  chrome.runtime.onInstalled.addListener(() => {
+    chromeService.ContextMenus.createParentMenu();
+    chromeService.ContextMenus.createGotoTabsPageMenu();
   });
 
   chrome.browserAction.onClicked.addListener(() => {

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -159,22 +159,22 @@ export namespace chromeService {
   }
 
   export namespace ContextMenus {
-    const appName = chrome.runtime.getManifest().name
-    const parentMenuId = `${appName}.mainMenu`
+    const appName = () => chrome.runtime.getManifest().name
+    const parentMenuId = () => `${appName}.mainMenu`
 
     export function createParentMenu(): void {
       chrome.contextMenus.create({
-        id: parentMenuId,
-        "title": appName,
+        id: parentMenuId(),
+        "title": appName(),
         "type": "normal",
         "contexts": ["all"],
       });
     }
 
-    export function createGotoTabsPageMenu():void {
+    export function createGotoTabsPageMenu(): void {
       chrome.contextMenus.create({
         "title": "tabページを開く",
-        "parentId": parentMenuId,
+        "parentId": parentMenuId(),
         "type": "normal",
         "contexts": ["all"],
         "onclick": chromeService.tab.createTabsPageTab

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -157,4 +157,28 @@ export namespace chromeService {
       });
     }
   }
+
+  export namespace ContextMenus {
+    const appName = chrome.runtime.getManifest().name
+    const parentMenuId = `${appName}.mainMenu`
+
+    export function createParentMenu(): void {
+      chrome.contextMenus.create({
+        id: parentMenuId,
+        "title": appName,
+        "type": "normal",
+        "contexts": ["all"],
+      });
+    }
+
+    export function createGotoTabsPageMenu():void {
+      chrome.contextMenus.create({
+        "title": "tabページを開く",
+        "parentId": parentMenuId,
+        "type": "normal",
+        "contexts": ["all"],
+        "onclick": chromeService.tab.createTabsPageTab
+      });
+    }
+  }
 }


### PR DESCRIPTION
公式に明記されているドキュメントを見つけられなかったが、 `chrome.contextMenus.create` はtypesでもvoidを返すように定義されている & 以前v３以降を試した時にそのままでは動かなかった

IDを外で定義して渡す方式に変更

### 参考

https://stackoverflow.com/a/67046535
https://retrorocket.biz/archives/771