### PR TITLE
actions/checkout を v1 から v6 に更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - name: npm install
         run: npm install
       - name: Run format check


### PR DESCRIPTION
## Summary
- `test.yml` の `actions/checkout@v1` を最新メジャー `v6` に更新

## Background
`actions/checkout@v1` は Node 12 ベースで GitHub Actions のサポートランタイムから外れて久しく、いずれ実行時警告/エラーになる懸念がある。v6 は Node 24 ランタイムを使用。

## Test plan
- [ ] PR 上で CI(build job) が緑になることを確認

Generated with Claude Code