### PR TITLE
Manifest V3へ移行

### DIFF
--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -1,38 +1,44 @@
 import { blockService } from './blockService';
 import { chromeService } from './chromeService';
 
-(() => {
-  chrome.runtime.onInstalled.addListener(() => {
-    chromeService.ContextMenus.createParentMenu();
-    chromeService.ContextMenus.createGotoTabsPageMenu();
-  });
+/**
+ * service workerではalertが使えないため、エラーをログ出力しバッジで通知する
+ * @param {unknown} error 発生したエラー
+ */
+function handleError(error: unknown): void {
+  console.error(error);
+  chrome.action.setBadgeBackgroundColor({ color: '#DD2222' });
+  chrome.action.setBadgeText({ text: '!' });
+}
 
-  chrome.browserAction.onClicked.addListener(() => {
-    chromeService.storage
-      .getTabLength()
-      .then((tabLength) => {
-        chrome.tabs.query(
-          { currentWindow: true },
-          (currentTabs: chrome.tabs.Tab[]) => {
-            const block = blockService.createBlock(
-              currentTabs,
-              new Date(),
-              tabLength
-            );
-
-            chromeService.storage
-              .setBlock(block)
-              .then((_) => chromeService.storage.setTabLength(tabLength + 1))
-              .then((_) => chromeService.tab.createTabsPageTab())
-              .then((_) => chromeService.tab.closeTabs(currentTabs))
-              .catch((error) => {
-                alert(error.message);
-              });
-          }
-        );
-      })
-      .catch((error) => {
-        alert(error.message);
-      });
+/**
+ * 現在のウィンドウの全タブを保存してtabsページを開き、元のタブを閉じる
+ * @return {Promise<void>}
+ */
+async function saveCurrentWindowTabs(): Promise<void> {
+  const tabLength = await chromeService.storage.getTabLength();
+  const currentTabs = await chromeService.tab.queryTabs({
+    currentWindow: true,
   });
-})();
+  const block = blockService.createBlock(currentTabs, new Date(), tabLength);
+  await chromeService.storage.setBlock(block);
+  await chromeService.storage.setTabLength(tabLength + 1);
+  await chromeService.tab.createTabsPageTab();
+  await chromeService.tab.closeTabs(currentTabs);
+  chrome.action.setBadgeText({ text: '' });
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chromeService.ContextMenus.createParentMenu();
+  chromeService.ContextMenus.createGotoTabsPageMenu();
+});
+
+chrome.contextMenus.onClicked.addListener((info) => {
+  if (info.menuItemId === chromeService.ContextMenus.gotoTabsPageMenuId) {
+    chromeService.tab.createTabsPageTab().catch(handleError);
+  }
+});
+
+chrome.action.onClicked.addListener(() => {
+  saveCurrentWindowTabs().catch(handleError);
+});

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -126,15 +126,8 @@ export namespace blockService {
       promiseArray.push(chromeService.storage.setBlock(block));
     });
 
-    Promise.all(promiseArray).then(() => {
-      chromeService.storage
-        .setTabLength(tabLength + json.length)
-        .then((_) => {
-          chrome.tabs.reload({ bypassCache: true });
-        })
-        .catch(function (reason) {
-          throw reason;
-        });
-    });
+    await Promise.all(promiseArray);
+    await chromeService.storage.setTabLength(tabLength + json.length);
+    chrome.tabs.reload({ bypassCache: true });
   }
 }

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -195,10 +195,26 @@ export namespace chromeService {
     }
 
     // eslint-disable-next-line require-jsdoc
+    export function queryTabs(
+      queryInfo: chrome.tabs.QueryInfo
+    ): Promise<chrome.tabs.Tab[]> {
+      return new Promise((resolve, reject) => {
+        chrome.tabs.query(queryInfo, (tabs) => {
+          const error = chrome.runtime.lastError;
+          if (error) {
+            reject(error);
+          } else {
+            resolve(tabs);
+          }
+        });
+      });
+    }
+
+    // eslint-disable-next-line require-jsdoc
     export async function createTabsPageTab(): Promise<void> {
       const url = chrome.runtime.getURL('tabs.html');
       await chrome.tabs.create({
-        selected: true,
+        active: true,
         url: url,
       });
     }
@@ -206,7 +222,8 @@ export namespace chromeService {
 
   export namespace ContextMenus {
     const appName = () => chrome.runtime.getManifest().name;
-    const parentMenuId = () => `${appName}.mainMenu`;
+    const parentMenuId = () => `${appName()}.mainMenu`;
+    export const gotoTabsPageMenuId = 'gotoTabsPage';
 
     // eslint-disable-next-line require-jsdoc
     export function createParentMenu(): void {
@@ -221,11 +238,11 @@ export namespace chromeService {
     // eslint-disable-next-line require-jsdoc
     export function createGotoTabsPageMenu(): void {
       chrome.contextMenus.create({
+        id: gotoTabsPageMenuId,
         title: chrome.i18n.getMessage('content_msg_open_tab_page'),
         parentId: parentMenuId(),
         type: 'normal',
         contexts: ['all'],
-        onclick: chromeService.tab.createTabsPageTab,
       });
     }
   }

--- a/src/js/zlib-deflate.js
+++ b/src/js/zlib-deflate.js
@@ -93,8 +93,9 @@ Usage: z_stream.deflateBound(sourceLen);
     TODO document
 */
 
+var ZLIB = globalThis.ZLIB;
 if( typeof ZLIB === 'undefined' ) {
-    alert('ZLIB is not defined.  SRC zlib.js before zlib-deflate.js')
+    throw new Error('ZLIB is not defined.  SRC zlib.js before zlib-deflate.js');
 }
 
 (function() {

--- a/src/js/zlib-inflate.js
+++ b/src/js/zlib-inflate.js
@@ -71,8 +71,9 @@ Usage: z_stream.inflateReset();
 
 */
 
+var ZLIB = globalThis.ZLIB;
 if( typeof ZLIB === 'undefined' ) {
-    alert('ZLIB is not defined.  SRC zlib.js before zlib-inflate.js')
+    throw new Error('ZLIB is not defined.  SRC zlib.js before zlib-inflate.js');
 }
 
 (function() {

--- a/src/js/zlib-wrapper.test.ts
+++ b/src/js/zlib-wrapper.test.ts
@@ -1,0 +1,26 @@
+import { zlibWrapper } from './zlib-wrapper';
+
+// Manifest V2時点(master)のzlib実装で生成した圧縮データ。
+// zlibのバンドル方法を変えてもstorage.sync上の既存データを
+// 読み書きできることを保証するゴールデンフィクスチャ。
+const masterDeflatedBase64 =
+  'eNqMj10OgjAQhE+zjxostJTH8tNrmIoNaDAg1MTjOy1IYpTEZLOZ2e432VKaE2P1aI2z56NxMBSrg4gyzoVIuEglsQJTZ07T/Eg8p0A9xm6ZMNY6N0xBapR9mtvQ2X3d3+CcnULunHNxnV2x4HbvhbT0Oz+z1+im75uPZLYRPS/+k/1993WAGYxrKdZ3ioHySqBlKZriqy289a2SXik/qzbuISDgQXtREDhQYEBUMUlGuV6ESoJAyUWonHREmaZMkYyW//AS/QUAAP//';
+
+const originalJson =
+  '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"},{"url":"http://google.com/test2","title":"google-test"},{"url":"https://example.jp/path?q=%E6%97%A5%E6%9C%AC%E8%AA%9E","title":"日本語タイトル🚀"}]}';
+
+describe('zlibWrapper', () => {
+  test('master時点の圧縮データを復元できる（既存データ互換）', (): void => {
+    expect(zlibWrapper.inflate(masterDeflatedBase64)).toBe(originalJson);
+  });
+
+  test('deflateの出力がmaster時点と一致する', (): void => {
+    expect(zlibWrapper.deflate(originalJson)).toBe(masterDeflatedBase64);
+  });
+
+  test('deflate→inflateの往復で元に戻る', (): void => {
+    expect(zlibWrapper.inflate(zlibWrapper.deflate(originalJson))).toBe(
+      originalJson
+    );
+  });
+});

--- a/src/js/zlib-wrapper.ts
+++ b/src/js/zlib-wrapper.ts
@@ -1,3 +1,12 @@
+// zlib*.jsは非モジュールのレガシーJSで、globalThis.ZLIBを介して相互参照する
+// side-effect importでbackground/tabs両バンドルに同梱し、ロード経路を一本化する
+// @ts-ignore
+import './zlib.js';
+// @ts-ignore
+import './zlib-deflate.js';
+// @ts-ignore
+import './zlib-inflate.js';
+
 export namespace zlibWrapper {
   const Buffer = require('buffer').Buffer;
 

--- a/src/js/zlib.js
+++ b/src/js/zlib.js
@@ -41,7 +41,7 @@
   (zlib format), rfc1951 (deflate format) and rfc1952 (gzip format).
 */
 
-var ZLIB = ( ZLIB || {} ); // ZLIB namespace initialization
+var ZLIB = globalThis.ZLIB = ( globalThis.ZLIB || {} ); // ZLIB namespace initialization
 
 // common definitions
 if(typeof ZLIB.common_initialized === 'undefined') {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,18 +1,12 @@
 {
   "name": "SyncTabClipper",
   "version": "0.2.1",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "__MSG_Description__",
   "default_locale": "en",
   "permissions": ["tabs", "storage", "contextMenus"],
   "background": {
-    "scripts": [
-      "js/zlib.js",
-      "js/zlib-deflate.js",
-      "js/zlib-inflate.js",
-      "js/background.js"
-    ],
-    "persistant": false
+    "service_worker": "js/background.js"
   },
   "icons": {
     "16": "images/icon16.png",
@@ -20,7 +14,7 @@
     "48": "images/icon48.png",
     "128": "images/icon128.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": {
       "16": "images/icon16.png"
     }

--- a/src/tabs.html
+++ b/src/tabs.html
@@ -3,9 +3,6 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <title>syncTabCliper</title>
-    <script src="js/zlib.js"></script>
-    <script src="js/zlib-deflate.js"></script>
-    <script src="js/zlib-inflate.js"></script>
     <script src="js/tabs.js"></script>
   </head>
   <body>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -43,11 +43,6 @@ module.exports = {
         { from: 'src/tabs.html', to: path.join(__dirname, 'dist/') },
         { from: 'src/manifest.json', to: path.join(__dirname, 'dist/') },
         {
-          context: 'src/js',
-          from: 'zlib*.js',
-          to: path.join(__dirname, 'dist/js/'),
-        },
-        {
           context: 'src/_locales',
           from: '*/*',
           to: path.join(__dirname, 'dist/_locales/'),


### PR DESCRIPTION
## 概要

Manifest V3 移行の PR 2/4（本体）。**base は #152（ビルド修復）のスタック PR** — #152 マージ後に master へ自動リターゲットされます。

2026-08-31 に Web Store から MV2 拡張が削除されるため、それまでに MV3 版を公開する必要があります（拡張は既に全ユーザーで無効化済み）。

## 変更内容

### manifest.json
- `manifest_version: 3`、`background.scripts` → `background.service_worker`、`browser_action` → `action`
- `persistant`（typo）はキーごと消滅。permissions は `tabs, storage, contextMenus` のまま変更なし

### zlib のバンドル統合（データ互換が最重要）
- `zlib.js` / `zlib-deflate.js` / `zlib-inflate.js` を `globalThis.ZLIB` 経由の相互参照に最小変更（webpack のモジュールスコープでファイル間グローバル共有が壊れるため）。zlib.js は CRLF のまま 1 行のみの diff
- `zlib-wrapper.ts` の side-effect import で background / tabs 両バンドルに同梱。tabs.html の `<script>` 3 本と webpack CopyPlugin の zlib コピーを削除し、ロード経路を一本化
- **圧縮アルゴリズム自体は無変更**。既存ユーザーの storage.sync データとの互換を、master 時点の実装で生成したゴールデンフィクスチャのテストで担保（`src/js/zlib-wrapper.test.ts`）

### service worker 対応
- `background.ts` を async/await 化し、リスナーはすべてトップレベル登録（SW 休止→再起動に対応）
- SW で使えない `alert()` を `console.error` + action バッジ「!」通知へ変更（保存成功時にバッジクリア。バッジ+storage.local でのエラー詳細表示は次 PR）
- `contextMenus.create({onclick})`（MV3 非対応）→ `id` 指定 + `contextMenus.onClicked` リスナーへ移行

### その他の修正
- `chrome.tabs.create({selected})` （非推奨）→ `{active}`
- `parentMenuId` が関数を文字列化していたバグ（`${appName}` → `${appName()}`）を修正
- `importAllDataJson` の `Promise.all` await 漏れを修正（インポート失敗が silent failure になり、呼び出し元 sideBar の catch → alert に届いていなかった）

## 検証

- テスト 17 件（ゴールデンテスト 3 件含む）/ lint / format:check / クリーンビルドすべてパス
- クリーンビルドの dist: MV3 manifest、zlib 単体ファイル消滅（background.js にバンドル、ZLIB 参照 200 箇所）、`alert` 0 件

### 手動確認（2026-08-01 実機確認）
- [x] `npm run build` → chrome://extensions で dist を「パッケージ化されていない拡張機能」として読み込み
- [x] ツールバーアイコンクリック → タブ群が保存され tabs ページが開き、元タブが閉じる
- [x] 右クリックメニュー「SyncTabClipper」→ タブページを開く（SW「無効」状態からの再起動でも動作確認済み）
- [x] tabs ページでの保存データの復元表示（zlib バンドル化後の解凍・表示が正常）
- [x] tabs ページからの削除・エクスポート/インポート
- [x] SW が「無効」表示になるまで放置してからアイコンクリック（休止→再起動パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
