### PR TITLE
バックグラウンドのエラーをtabsページに表示する仕組みを追加

### DIFF
--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -25,7 +25,6 @@ async function saveCurrentWindowTabs(): Promise<void> {
   await chromeService.storage.setTabLength(tabLength + 1);
   await chromeService.tab.createTabsPageTab();
   await chromeService.tab.closeTabs(currentTabs);
-  await chromeService.errorLog.clear();
 }
 
 chrome.runtime.onInstalled.addListener(() => {

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -8,8 +8,7 @@ import { chromeService } from './chromeService';
  */
 function handleError(error: unknown): void {
   console.error(error);
-  const message = error instanceof Error ? error.message : String(error);
-  chromeService.errorLog.set(message).catch(console.error);
+  chromeService.errorLog.set(error).catch(console.error);
 }
 
 /**

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -2,13 +2,14 @@ import { blockService } from './blockService';
 import { chromeService } from './chromeService';
 
 /**
- * service workerではalertが使えないため、エラーをログ出力しバッジで通知する
+ * service workerではalertが使えないため、エラーをログ出力し、
+ * storage.local + actionバッジ経由でtabsページのErrorDisplayに通知する
  * @param {unknown} error 発生したエラー
  */
 function handleError(error: unknown): void {
   console.error(error);
-  chrome.action.setBadgeBackgroundColor({ color: '#DD2222' });
-  chrome.action.setBadgeText({ text: '!' });
+  const message = error instanceof Error ? error.message : String(error);
+  chromeService.errorLog.set(message).catch(console.error);
 }
 
 /**
@@ -25,7 +26,7 @@ async function saveCurrentWindowTabs(): Promise<void> {
   await chromeService.storage.setTabLength(tabLength + 1);
   await chromeService.tab.createTabsPageTab();
   await chromeService.tab.closeTabs(currentTabs);
-  chrome.action.setBadgeText({ text: '' });
+  await chromeService.errorLog.clear();
 }
 
 chrome.runtime.onInstalled.addListener(() => {

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -94,8 +94,10 @@ export namespace blockService {
   }
 
   // eslint-disable-next-line require-jsdoc
-  export function exportAllDataJson(targetElement: HTMLInputElement): void {
-    chromeService.storage.getAllBlock().then((blocks) => {
+  export function exportAllDataJson(
+    targetElement: HTMLInputElement
+  ): Promise<void> {
+    return chromeService.storage.getAllBlock().then((blocks) => {
       targetElement.value = JSON.stringify(blocks.map(blockToJsonObj));
     });
   }

--- a/src/js/chromeService.test.ts
+++ b/src/js/chromeService.test.ts
@@ -52,6 +52,12 @@ describe('chromeService.errorLog', (): void => {
     expect(setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#DD2222' });
   });
 
+  test('setにErrorインスタンスを渡すとmessageが保存される', async (): Promise<void> => {
+    await chromeService.errorLog.set(new Error('boom'));
+
+    expect(localData[chromeService.errorLog.errorKey]).toBe('boom');
+  });
+
   test('getで取得しても保存とバッジは残る', async (): Promise<void> => {
     await chromeService.errorLog.set('boom');
     setBadgeText.mockClear();

--- a/src/js/chromeService.test.ts
+++ b/src/js/chromeService.test.ts
@@ -64,6 +64,24 @@ describe('chromeService.errorLog', (): void => {
     await expect(chromeService.errorLog.pop()).resolves.toBeNull();
   });
 
+  test('lastError発生時はErrorインスタンスでrejectする', async (): Promise<void> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome.storage.local.set = (
+      _obj: { [key: string]: string },
+      cb: () => void
+    ): void => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).chrome.runtime.lastError = { message: 'quota exceeded' };
+      cb();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (global as any).chrome.runtime.lastError;
+    };
+
+    const result = chromeService.errorLog.set('boom');
+    await expect(result).rejects.toBeInstanceOf(Error);
+    await expect(result).rejects.toThrow('quota exceeded');
+  });
+
   test('clearで保存とバッジが消える', async (): Promise<void> => {
     await chromeService.errorLog.set('boom');
     await chromeService.errorLog.clear();

--- a/src/js/chromeService.test.ts
+++ b/src/js/chromeService.test.ts
@@ -52,16 +52,17 @@ describe('chromeService.errorLog', (): void => {
     expect(setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#DD2222' });
   });
 
-  test('popで取り出すと保存とバッジがクリアされる', async (): Promise<void> => {
+  test('getで取得しても保存とバッジは残る', async (): Promise<void> => {
     await chromeService.errorLog.set('boom');
+    setBadgeText.mockClear();
 
-    await expect(chromeService.errorLog.pop()).resolves.toBe('boom');
-    expect(localData[chromeService.errorLog.errorKey]).toBeUndefined();
-    expect(setBadgeText).toHaveBeenLastCalledWith({ text: '' });
+    await expect(chromeService.errorLog.get()).resolves.toBe('boom');
+    expect(localData[chromeService.errorLog.errorKey]).toBe('boom');
+    expect(setBadgeText).not.toHaveBeenCalled();
   });
 
-  test('未保存時のpopはnullを返す', async (): Promise<void> => {
-    await expect(chromeService.errorLog.pop()).resolves.toBeNull();
+  test('未保存時のgetはnullを返す', async (): Promise<void> => {
+    await expect(chromeService.errorLog.get()).resolves.toBeNull();
   });
 
   test('lastError発生時はErrorインスタンスでrejectする', async (): Promise<void> => {

--- a/src/js/chromeService.test.ts
+++ b/src/js/chromeService.test.ts
@@ -1,3 +1,74 @@
-describe('chromeService', (): void => {
-  test('dummy test', (): void => {});
+import { chromeService } from './chromeService';
+
+describe('chromeService.errorLog', (): void => {
+  let localData: { [key: string]: string };
+  const setBadgeText = jest.fn();
+  const setBadgeBackgroundColor = jest.fn();
+
+  beforeEach((): void => {
+    localData = {};
+    setBadgeText.mockClear();
+    setBadgeBackgroundColor.mockClear();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      runtime: {},
+      storage: {
+        local: {
+          set: (obj: { [key: string]: string }, cb: () => void): void => {
+            Object.assign(localData, obj);
+            cb();
+          },
+          get: (
+            keys: string[],
+            cb: (items: { [key: string]: string }) => void
+          ): void => {
+            const res: { [key: string]: string } = {};
+            for (const key of keys) {
+              const value = localData[key];
+              if (value != null) {
+                res[key] = value;
+              }
+            }
+            cb(res);
+          },
+          remove: (key: string, cb: () => void): void => {
+            delete localData[key];
+            cb();
+          },
+        },
+      },
+      action: {
+        setBadgeText: setBadgeText,
+        setBadgeBackgroundColor: setBadgeBackgroundColor,
+      },
+    };
+  });
+
+  test('setでエラーが保存されバッジが立つ', async (): Promise<void> => {
+    await chromeService.errorLog.set('boom');
+
+    expect(localData[chromeService.errorLog.errorKey]).toBe('boom');
+    expect(setBadgeText).toHaveBeenCalledWith({ text: '!' });
+    expect(setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#DD2222' });
+  });
+
+  test('popで取り出すと保存とバッジがクリアされる', async (): Promise<void> => {
+    await chromeService.errorLog.set('boom');
+
+    await expect(chromeService.errorLog.pop()).resolves.toBe('boom');
+    expect(localData[chromeService.errorLog.errorKey]).toBeUndefined();
+    expect(setBadgeText).toHaveBeenLastCalledWith({ text: '' });
+  });
+
+  test('未保存時のpopはnullを返す', async (): Promise<void> => {
+    await expect(chromeService.errorLog.pop()).resolves.toBeNull();
+  });
+
+  test('clearで保存とバッジが消える', async (): Promise<void> => {
+    await chromeService.errorLog.set('boom');
+    await chromeService.errorLog.clear();
+
+    expect(localData[chromeService.errorLog.errorKey]).toBeUndefined();
+    expect(setBadgeText).toHaveBeenLastCalledWith({ text: '' });
+  });
 });

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -224,21 +224,22 @@ export namespace chromeService {
     export const errorKey = 'error';
 
     /**
-     * エラーメッセージをchrome.storage.localに保存し、actionバッジで通知する。
+     * エラーをchrome.storage.localに保存し、actionバッジで通知する。
      * service workerではalertが使えないため、tabsページのErrorDisplayが
-     * このエラーを表示する。保存とバッジはユーザーがアラートを閉じるか
-     * 保存操作が成功するまで残す（表示しただけでは消費しない）
-     * @param {string} message エラーメッセージ
+     * このエラーを表示する。保存とバッジはユーザーがエラーを確認するか
+     * 保存操作が成功するまで残す
+     * @param {unknown} error 発生したエラー（Error以外はStringで文字列化）
      * @return {Promise<void>}
      */
-    export function set(message: string): Promise<void> {
+    export function set(error: unknown): Promise<void> {
+      const message = error instanceof Error ? error.message : String(error);
       const setObj: { [key: string]: string } = {};
       setObj[errorKey] = message;
       return new Promise((resolve, reject) => {
         chrome.storage.local.set(setObj, () => {
-          const error = chrome.runtime.lastError;
-          if (error) {
-            reject(new Error(error.message));
+          const lastError = chrome.runtime.lastError;
+          if (lastError) {
+            reject(new Error(lastError.message));
           } else {
             chrome.action.setBadgeBackgroundColor({ color: '#DD2222' });
             chrome.action.setBadgeText({ text: '!' });

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -220,6 +220,76 @@ export namespace chromeService {
     }
   }
 
+  export namespace errorLog {
+    export const errorKey = 'error';
+
+    /**
+     * エラーメッセージをchrome.storage.localに保存し、actionバッジで通知する。
+     * service workerではalertが使えないため、tabsページのErrorDisplayが
+     * このエラーを表示・クリアする
+     * @param {string} message エラーメッセージ
+     * @return {Promise<void>}
+     */
+    export function set(message: string): Promise<void> {
+      const setObj: { [key: string]: string } = {};
+      setObj[errorKey] = message;
+      return new Promise((resolve, reject) => {
+        chrome.storage.local.set(setObj, () => {
+          const error = chrome.runtime.lastError;
+          if (error) {
+            reject(error);
+          } else {
+            chrome.action.setBadgeBackgroundColor({ color: '#DD2222' });
+            chrome.action.setBadgeText({ text: '!' });
+            resolve();
+          }
+        });
+      });
+    }
+
+    /**
+     * 保存されたエラーメッセージとバッジをクリアする
+     * @return {Promise<void>}
+     */
+    export function clear(): Promise<void> {
+      return new Promise((resolve, reject) => {
+        chrome.storage.local.remove(errorKey, () => {
+          const error = chrome.runtime.lastError;
+          if (error) {
+            reject(error);
+          } else {
+            chrome.action.setBadgeText({ text: '' });
+            resolve();
+          }
+        });
+      });
+    }
+
+    /**
+     * 保存されたエラーメッセージを取り出し、保存とバッジをクリアする
+     * @return {Promise<string | null>} エラーメッセージ。未保存ならnull
+     */
+    export function pop(): Promise<string | null> {
+      return new Promise((resolve, reject) => {
+        chrome.storage.local.get([errorKey], (item) => {
+          const error = chrome.runtime.lastError;
+          if (error) {
+            reject(error);
+            return;
+          }
+          const message = item[errorKey];
+          if (message == null) {
+            resolve(null);
+            return;
+          }
+          clear()
+            .then(() => resolve(message))
+            .catch(reject);
+        });
+      });
+    }
+  }
+
   export namespace ContextMenus {
     const appName = () => chrome.runtime.getManifest().name;
     const parentMenuId = () => `${appName()}.mainMenu`;

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -13,7 +13,7 @@ export namespace chromeService {
         chrome.storage.sync.remove(key, () => {
           const error = chrome.runtime.lastError;
           if (error) {
-            reject(error);
+            reject(new Error(error.message));
           } else {
             resolve();
           }
@@ -29,7 +29,7 @@ export namespace chromeService {
         chrome.storage.sync.set(setObj, () => {
           const error = chrome.runtime.lastError;
           if (error) {
-            reject(error);
+            reject(new Error(error.message));
           } else {
             resolve();
           }
@@ -43,7 +43,7 @@ export namespace chromeService {
         chrome.storage.sync.get([key], (item) => {
           const error = chrome.runtime.lastError;
           if (error) {
-            reject(error);
+            reject(new Error(error.message));
           } else {
             resolve(item[key]);
           }
@@ -57,7 +57,7 @@ export namespace chromeService {
         chrome.storage.sync.clear(function () {
           const error = chrome.runtime.lastError;
           if (error) {
-            reject(error);
+            reject(new Error(error.message));
           } else {
             resolve();
           }
@@ -156,7 +156,7 @@ export namespace chromeService {
         chrome.tabs.create(properties, () => {
           const error = chrome.runtime.lastError;
           if (error) {
-            reject(error);
+            reject(new Error(error.message));
           } else {
             resolve();
           }
@@ -170,7 +170,7 @@ export namespace chromeService {
         chrome.tabs.remove(tab.id!, () => {
           const error = chrome.runtime.lastError;
           if (error) {
-            reject(error);
+            reject(new Error(error.message));
           } else {
             resolve();
           }
@@ -202,7 +202,7 @@ export namespace chromeService {
         chrome.tabs.query(queryInfo, (tabs) => {
           const error = chrome.runtime.lastError;
           if (error) {
-            reject(error);
+            reject(new Error(error.message));
           } else {
             resolve(tabs);
           }
@@ -237,7 +237,7 @@ export namespace chromeService {
         chrome.storage.local.set(setObj, () => {
           const error = chrome.runtime.lastError;
           if (error) {
-            reject(error);
+            reject(new Error(error.message));
           } else {
             chrome.action.setBadgeBackgroundColor({ color: '#DD2222' });
             chrome.action.setBadgeText({ text: '!' });
@@ -256,7 +256,7 @@ export namespace chromeService {
         chrome.storage.local.remove(errorKey, () => {
           const error = chrome.runtime.lastError;
           if (error) {
-            reject(error);
+            reject(new Error(error.message));
           } else {
             chrome.action.setBadgeText({ text: '' });
             resolve();
@@ -274,7 +274,7 @@ export namespace chromeService {
         chrome.storage.local.get([errorKey], (item) => {
           const error = chrome.runtime.lastError;
           if (error) {
-            reject(error);
+            reject(new Error(error.message));
             return;
           }
           const message = item[errorKey];

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -226,7 +226,8 @@ export namespace chromeService {
     /**
      * エラーメッセージをchrome.storage.localに保存し、actionバッジで通知する。
      * service workerではalertが使えないため、tabsページのErrorDisplayが
-     * このエラーを表示・クリアする
+     * このエラーを表示する。保存とバッジはユーザーがアラートを閉じるか
+     * 保存操作が成功するまで残す（表示しただけでは消費しない）
      * @param {string} message エラーメッセージ
      * @return {Promise<void>}
      */
@@ -266,10 +267,10 @@ export namespace chromeService {
     }
 
     /**
-     * 保存されたエラーメッセージを取り出し、保存とバッジをクリアする
+     * 保存されたエラーメッセージを取得する。保存とバッジはクリアしない
      * @return {Promise<string | null>} エラーメッセージ。未保存ならnull
      */
-    export function pop(): Promise<string | null> {
+    export function get(): Promise<string | null> {
       return new Promise((resolve, reject) => {
         chrome.storage.local.get([errorKey], (item) => {
           const error = chrome.runtime.lastError;
@@ -277,14 +278,7 @@ export namespace chromeService {
             reject(new Error(error.message));
             return;
           }
-          const message = item[errorKey];
-          if (message == null) {
-            resolve(null);
-            return;
-          }
-          clear()
-            .then(() => resolve(message))
-            .catch(reject);
+          resolve(item[errorKey] ?? null);
         });
       });
     }

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -226,8 +226,8 @@ export namespace chromeService {
     /**
      * エラーをchrome.storage.localに保存し、actionバッジで通知する。
      * service workerではalertが使えないため、tabsページのErrorDisplayが
-     * このエラーを表示する。保存とバッジはユーザーがエラーを確認するか
-     * 保存操作が成功するまで残す
+     * このエラーを表示する。保存とバッジはユーザーがエラーを確認する
+     * （可視状態のtabsページに表示される）まで残す
      * @param {unknown} error 発生したエラー（Error以外はStringで文字列化）
      * @return {Promise<void>}
      */

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -19,12 +19,17 @@ const Block: React.FC<BlockProps> = (props) => {
   };
 
   const changeBlock = (newBlock: model.Block) => {
-    chromeService.storage.setBlock(newBlock).then((_) => {
-      setNowBlock(newBlock);
-      if (newBlock.tabs.length <= 0) {
-        props.deleteBlock();
-      }
-    });
+    chromeService.storage
+      .setBlock(newBlock)
+      .then((_) => {
+        setNowBlock(newBlock);
+        if (newBlock.tabs.length <= 0) {
+          props.deleteBlock();
+        }
+      })
+      .catch((error) => {
+        chromeService.errorLog.set(error.message).catch(console.error);
+      });
   };
 
   const deleteClick = (index: number) => {

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -28,7 +28,10 @@ const Block: React.FC<BlockProps> = (props) => {
         }
       })
       .catch((error) => {
-        chromeService.errorLog.set(error.message).catch(console.error);
+        // chromeServiceはchrome.runtime.lastError（Errorインスタンスでない
+        // {message?: string}）でrejectするためinstanceofでガードする
+        const message = error instanceof Error ? error.message : String(error);
+        chromeService.errorLog.set(message).catch(console.error);
       });
   };
 

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -28,10 +28,7 @@ const Block: React.FC<BlockProps> = (props) => {
         }
       })
       .catch((error) => {
-        // chromeServiceはchrome.runtime.lastError（Errorインスタンスでない
-        // {message?: string}）でrejectするためinstanceofでガードする
-        const message = error instanceof Error ? error.message : String(error);
-        chromeService.errorLog.set(message).catch(console.error);
+        chromeService.errorLog.set(error).catch(console.error);
       });
   };
 
@@ -52,9 +49,13 @@ const Block: React.FC<BlockProps> = (props) => {
         chromeService.tab.createTabs({ url: tab.url, active: false })
       );
     }
-    Promise.all(promiseArray).then(() => {
-      deleteBlock();
-    });
+    Promise.all(promiseArray)
+      .then(() => {
+        deleteBlock();
+      })
+      .catch((error) => {
+        chromeService.errorLog.set(error).catch(console.error);
+      });
   };
 
   const deleteBlock = () => {

--- a/src/js/components/error.test.tsx
+++ b/src/js/components/error.test.tsx
@@ -16,10 +16,36 @@ describe('ErrorDisplay', (): void => {
     ) => void
   >;
   let container: HTMLDivElement;
+  const setBadgeText = jest.fn();
+
+  const setVisibility = (state: 'visible' | 'hidden'): void => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => state,
+    });
+  };
+
+  const errorKey = chromeService.errorLog.errorKey;
+
+  const mount = async (): Promise<void> => {
+    await act(async () => {
+      ReactDOM.render(<ErrorDisplay />, container);
+    });
+  };
+
+  const notifyRemoved = async (): Promise<void> => {
+    await act(async () => {
+      for (const listener of onChangedListeners) {
+        listener({ [errorKey]: { oldValue: 'boom' } }, 'local');
+      }
+    });
+  };
 
   beforeEach((): void => {
     localData = {};
     onChangedListeners = [];
+    setBadgeText.mockClear();
+    setVisibility('visible');
     container = document.createElement('div');
     document.body.appendChild(container);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -62,7 +88,7 @@ describe('ErrorDisplay', (): void => {
         },
       },
       action: {
-        setBadgeText: jest.fn(),
+        setBadgeText: setBadgeText,
         setBadgeBackgroundColor: jest.fn(),
       },
     };
@@ -73,24 +99,69 @@ describe('ErrorDisplay', (): void => {
     container.remove();
   });
 
-  test('マウント時に保存済みエラーを表示する（保存は消費しない）', async (): Promise<void> => {
-    localData[chromeService.errorLog.errorKey] = 'boom';
+  test('可視ページでは表示した時点で保存とバッジをクリアし表示は残す', async (): Promise<void> => {
+    localData[errorKey] = 'boom';
 
+    await mount();
+
+    expect(container.textContent).toContain('boom');
+    expect(localData[errorKey]).toBeUndefined();
+    expect(setBadgeText).toHaveBeenCalledWith({ text: '' });
+  });
+
+  test('非可視ページでは表示するが保存とバッジは消費しない', async (): Promise<void> => {
+    setVisibility('hidden');
+    localData[errorKey] = 'boom';
+
+    await mount();
+
+    expect(container.textContent).toContain('boom');
+    expect(localData[errorKey]).toBe('boom');
+    expect(setBadgeText).not.toHaveBeenCalled();
+  });
+
+  test('非可視ページが可視になった時点で保存とバッジをクリアする', async (): Promise<void> => {
+    setVisibility('hidden');
+    localData[errorKey] = 'boom';
+    await mount();
+    expect(localData[errorKey]).toBe('boom');
+
+    setVisibility('visible');
     await act(async () => {
-      ReactDOM.render(<ErrorDisplay />, container);
+      document.dispatchEvent(new Event('visibilitychange'));
     });
 
     expect(container.textContent).toContain('boom');
-    // 他のtabsページでも表示できるよう、表示しただけでは保存を消費しない
-    expect(localData[chromeService.errorLog.errorKey]).toBe('boom');
+    expect(localData[errorKey]).toBeUndefined();
+    expect(setBadgeText).toHaveBeenCalledWith({ text: '' });
+  });
+
+  test('非可視ページは他ページでの確認済みクリアに追随して非表示になる', async (): Promise<void> => {
+    setVisibility('hidden');
+    localData[errorKey] = 'boom';
+    await mount();
+    expect(container.textContent).toContain('boom');
+
+    delete localData[errorKey];
+    await notifyRemoved();
+
+    expect(container.textContent).toBe('');
+  });
+
+  test('可視ページは確認済みクリア後もアラートを表示し続ける', async (): Promise<void> => {
+    localData[errorKey] = 'boom';
+    await mount();
+
+    // 自身の消費によるstorage変更イベントが届いても表示は取り下げない
+    await notifyRemoved();
+
+    expect(container.textContent).toContain('boom');
   });
 
   test('閉じると非表示になり保存とバッジがクリアされる', async (): Promise<void> => {
-    localData[chromeService.errorLog.errorKey] = 'boom';
-
-    await act(async () => {
-      ReactDOM.render(<ErrorDisplay />, container);
-    });
+    setVisibility('hidden');
+    localData[errorKey] = 'boom';
+    await mount();
 
     const closeButton =
       container.querySelector<HTMLAnchorElement>('a.uk-alert-close')!;
@@ -99,62 +170,23 @@ describe('ErrorDisplay', (): void => {
     });
 
     expect(container.textContent).toBe('');
-    expect(localData[chromeService.errorLog.errorKey]).toBeUndefined();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((global as any).chrome.action.setBadgeText).toHaveBeenCalledWith({
-      text: '',
-    });
-  });
-
-  test('他ページでのクリアに追随して非表示になる', async (): Promise<void> => {
-    localData[chromeService.errorLog.errorKey] = 'boom';
-
-    await act(async () => {
-      ReactDOM.render(<ErrorDisplay />, container);
-    });
-    expect(container.textContent).toContain('boom');
-
-    delete localData[chromeService.errorLog.errorKey];
-    await act(async () => {
-      for (const listener of onChangedListeners) {
-        listener(
-          {
-            [chromeService.errorLog.errorKey]: {
-              oldValue: 'boom',
-            },
-          },
-          'local'
-        );
-      }
-    });
-
-    expect(container.textContent).toBe('');
+    expect(localData[errorKey]).toBeUndefined();
+    expect(setBadgeText).toHaveBeenCalledWith({ text: '' });
   });
 
   test('未保存時は何も表示しない', async (): Promise<void> => {
-    await act(async () => {
-      ReactDOM.render(<ErrorDisplay />, container);
-    });
+    await mount();
 
     expect(container.textContent).toBe('');
   });
 
   test('表示中にstorage.onChangedで新しいエラーが届くと表示する', async (): Promise<void> => {
-    await act(async () => {
-      ReactDOM.render(<ErrorDisplay />, container);
-    });
+    await mount();
 
-    localData[chromeService.errorLog.errorKey] = 'late error';
+    localData[errorKey] = 'late error';
     await act(async () => {
       for (const listener of onChangedListeners) {
-        listener(
-          {
-            [chromeService.errorLog.errorKey]: {
-              newValue: 'late error',
-            },
-          },
-          'local'
-        );
+        listener({ [errorKey]: { newValue: 'late error' } }, 'local');
       }
     });
 

--- a/src/js/components/error.test.tsx
+++ b/src/js/components/error.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { ErrorDisplay } from './error';
+import { chromeService } from '../chromeService';
+
+describe('ErrorDisplay', (): void => {
+  let localData: { [key: string]: string };
+  let onChangedListeners: Array<
+    (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string
+    ) => void
+  >;
+  let container: HTMLDivElement;
+
+  beforeEach((): void => {
+    localData = {};
+    onChangedListeners = [];
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      runtime: {},
+      storage: {
+        local: {
+          set: (obj: { [key: string]: string }, cb: () => void): void => {
+            Object.assign(localData, obj);
+            cb();
+          },
+          get: (
+            keys: string[],
+            cb: (items: { [key: string]: string }) => void
+          ): void => {
+            const res: { [key: string]: string } = {};
+            for (const key of keys) {
+              const value = localData[key];
+              if (value != null) {
+                res[key] = value;
+              }
+            }
+            cb(res);
+          },
+          remove: (key: string, cb: () => void): void => {
+            delete localData[key];
+            cb();
+          },
+        },
+        onChanged: {
+          addListener: (
+            listener: (
+              changes: { [key: string]: chrome.storage.StorageChange },
+              areaName: string
+            ) => void
+          ): void => {
+            onChangedListeners.push(listener);
+          },
+          removeListener: jest.fn(),
+        },
+      },
+      action: {
+        setBadgeText: jest.fn(),
+        setBadgeBackgroundColor: jest.fn(),
+      },
+    };
+  });
+
+  afterEach((): void => {
+    ReactDOM.unmountComponentAtNode(container);
+    container.remove();
+  });
+
+  test('マウント時に保存済みエラーを表示する（保存は消費しない）', async (): Promise<void> => {
+    localData[chromeService.errorLog.errorKey] = 'boom';
+
+    await act(async () => {
+      ReactDOM.render(<ErrorDisplay />, container);
+    });
+
+    expect(container.textContent).toContain('boom');
+    // 他のtabsページでも表示できるよう、表示しただけでは保存を消費しない
+    expect(localData[chromeService.errorLog.errorKey]).toBe('boom');
+  });
+
+  test('閉じると非表示になり保存とバッジがクリアされる', async (): Promise<void> => {
+    localData[chromeService.errorLog.errorKey] = 'boom';
+
+    await act(async () => {
+      ReactDOM.render(<ErrorDisplay />, container);
+    });
+
+    const closeButton =
+      container.querySelector<HTMLAnchorElement>('a.uk-alert-close')!;
+    await act(async () => {
+      closeButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toBe('');
+    expect(localData[chromeService.errorLog.errorKey]).toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((global as any).chrome.action.setBadgeText).toHaveBeenCalledWith({
+      text: '',
+    });
+  });
+
+  test('他ページでのクリアに追随して非表示になる', async (): Promise<void> => {
+    localData[chromeService.errorLog.errorKey] = 'boom';
+
+    await act(async () => {
+      ReactDOM.render(<ErrorDisplay />, container);
+    });
+    expect(container.textContent).toContain('boom');
+
+    delete localData[chromeService.errorLog.errorKey];
+    await act(async () => {
+      for (const listener of onChangedListeners) {
+        listener(
+          {
+            [chromeService.errorLog.errorKey]: {
+              oldValue: 'boom',
+            },
+          },
+          'local'
+        );
+      }
+    });
+
+    expect(container.textContent).toBe('');
+  });
+
+  test('未保存時は何も表示しない', async (): Promise<void> => {
+    await act(async () => {
+      ReactDOM.render(<ErrorDisplay />, container);
+    });
+
+    expect(container.textContent).toBe('');
+  });
+
+  test('表示中にstorage.onChangedで新しいエラーが届くと表示する', async (): Promise<void> => {
+    await act(async () => {
+      ReactDOM.render(<ErrorDisplay />, container);
+    });
+
+    localData[chromeService.errorLog.errorKey] = 'late error';
+    await act(async () => {
+      for (const listener of onChangedListeners) {
+        listener(
+          {
+            [chromeService.errorLog.errorKey]: {
+              newValue: 'late error',
+            },
+          },
+          'local'
+        );
+      }
+    });
+
+    expect(container.textContent).toContain('late error');
+  });
+});

--- a/src/js/components/error.tsx
+++ b/src/js/components/error.tsx
@@ -5,24 +5,21 @@ export const ErrorDisplay: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const showError = (message: string | null) => {
-      if (message != null) {
-        setError(message);
-      }
-    };
-    chromeService.errorLog.pop().then(showError).catch(console.error);
+    // 表示時にはエラーを消費（クリア）しない。クリアしてしまうと、
+    // 別ウィンドウなどで既に開いているtabsページが先に消費し、
+    // 後から開いたページに何も表示されなくなる
+    chromeService.errorLog.get().then(setError).catch(console.error);
 
-    // ページ表示中に発生したエラー（tabsページ内の操作やbackground由来）も
-    // 即時表示できるようstorage.localの変更を監視する
+    // ページ表示中に発生したエラー（tabsページ内の操作やbackground由来）の
+    // 即時表示と、他ページでの閉じる操作・保存成功によるクリアへの追随の
+    // ためstorage.localの変更を監視する
     const onChanged = (
       changes: { [key: string]: chrome.storage.StorageChange },
       areaName: string
     ) => {
-      if (
-        areaName === 'local' &&
-        changes[chromeService.errorLog.errorKey]?.newValue != null
-      ) {
-        chromeService.errorLog.pop().then(showError).catch(console.error);
+      const change = changes[chromeService.errorLog.errorKey];
+      if (areaName === 'local' && change != null) {
+        setError(change.newValue ?? null);
       }
     };
     chrome.storage.onChanged.addListener(onChanged);
@@ -32,15 +29,17 @@ export const ErrorDisplay: React.FC = () => {
   if (error == null) {
     return null;
   }
+
+  const close = () => {
+    setError(null);
+    chromeService.errorLog.clear().catch(console.error);
+  };
+
   // data-uk-alertを付けるとUIkitがReactを介さずDOMノードを削除してしまい
   // 以降の再レンダリングと不整合を起こすため、閉じる処理はReactのstateで行う
   return (
     <div className="uk-alert uk-alert-danger">
-      <a
-        className="uk-alert-close"
-        data-uk-close="true"
-        onClick={() => setError(null)}
-      ></a>
+      <a className="uk-alert-close" data-uk-close="true" onClick={close}></a>
       <p>{error}</p>
     </div>
   );

--- a/src/js/components/error.tsx
+++ b/src/js/components/error.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { chromeService } from '../chromeService';
+
+export const ErrorDisplay: React.FC = () => {
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const showError = (message: string | null) => {
+      if (message != null) {
+        setError(message);
+      }
+    };
+    chromeService.errorLog.pop().then(showError).catch(console.error);
+
+    // ページ表示中に発生したエラー（tabsページ内の操作やbackground由来）も
+    // 即時表示できるようstorage.localの変更を監視する
+    const onChanged = (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string
+    ) => {
+      if (
+        areaName === 'local' &&
+        changes[chromeService.errorLog.errorKey]?.newValue != null
+      ) {
+        chromeService.errorLog.pop().then(showError).catch(console.error);
+      }
+    };
+    chrome.storage.onChanged.addListener(onChanged);
+    return () => chrome.storage.onChanged.removeListener(onChanged);
+  }, []);
+
+  if (error == null) {
+    return null;
+  }
+  return (
+    <div className="uk-alert-danger" data-uk-alert="true">
+      <a className="uk-alert-close" data-uk-close="true"></a>
+      <p>{error}</p>
+    </div>
+  );
+};

--- a/src/js/components/error.tsx
+++ b/src/js/components/error.tsx
@@ -32,9 +32,15 @@ export const ErrorDisplay: React.FC = () => {
   if (error == null) {
     return null;
   }
+  // data-uk-alertを付けるとUIkitがReactを介さずDOMノードを削除してしまい
+  // 以降の再レンダリングと不整合を起こすため、閉じる処理はReactのstateで行う
   return (
-    <div className="uk-alert-danger" data-uk-alert="true">
-      <a className="uk-alert-close" data-uk-close="true"></a>
+    <div className="uk-alert uk-alert-danger">
+      <a
+        className="uk-alert-close"
+        data-uk-close="true"
+        onClick={() => setError(null)}
+      ></a>
       <p>{error}</p>
     </div>
   );

--- a/src/js/components/error.tsx
+++ b/src/js/components/error.tsx
@@ -5,26 +5,48 @@ export const ErrorDisplay: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // 表示時にはエラーを消費（クリア）しない。クリアしてしまうと、
-    // 別ウィンドウなどで既に開いているtabsページが先に消費し、
-    // 後から開いたページに何も表示されなくなる
     chromeService.errorLog.get().then(setError).catch(console.error);
 
     // ページ表示中に発生したエラー（tabsページ内の操作やbackground由来）の
-    // 即時表示と、他ページでの閉じる操作・保存成功によるクリアへの追随の
-    // ためstorage.localの変更を監視する
+    // 即時表示と、他ページでの確認済みクリアへの追随のため
+    // storage.localの変更を監視する
     const onChanged = (
       changes: { [key: string]: chrome.storage.StorageChange },
       areaName: string
     ) => {
       const change = changes[chromeService.errorLog.errorKey];
       if (areaName === 'local' && change != null) {
-        setError(change.newValue ?? null);
+        if (change.newValue != null) {
+          setError(change.newValue);
+        } else if (document.visibilityState === 'hidden') {
+          // ユーザーが他の可視ページでエラーを確認（消費）した。
+          // このページは見えていないので表示を取り下げる。
+          // 可視ページでは確認済みのアラートをリロードか×まで残す
+          setError(null);
+        }
       }
     };
     chrome.storage.onChanged.addListener(onChanged);
     return () => chrome.storage.onChanged.removeListener(onChanged);
   }, []);
+
+  // アラートがユーザーの目に入った時点で保存とバッジをクリア（確認済み扱い）。
+  // マウント時に消費してしまうと、裏で開いているページが先に消費して
+  // 後から開いたページに表示されなくなるため、可視状態になるまで消費しない
+  useEffect(() => {
+    if (error == null) {
+      return;
+    }
+    const consumeIfVisible = () => {
+      if (document.visibilityState === 'visible') {
+        chromeService.errorLog.clear().catch(console.error);
+      }
+    };
+    consumeIfVisible();
+    document.addEventListener('visibilitychange', consumeIfVisible);
+    return () =>
+      document.removeEventListener('visibilitychange', consumeIfVisible);
+  }, [error]);
 
   if (error == null) {
     return null;

--- a/src/js/components/main.tsx
+++ b/src/js/components/main.tsx
@@ -1,6 +1,7 @@
 import { model } from '../types/interface';
 import React, { useState } from 'react';
 import Block from './block';
+import { ErrorDisplay } from './error';
 
 interface MainProps {
   Block: model.Block[];
@@ -18,6 +19,7 @@ const Main: React.FC<MainProps> = (props) => {
   if (nowBlocks.length > 0) {
     return (
       <div>
+        <ErrorDisplay />
         {nowBlocks.map((block, index) => {
           return (
             <Block
@@ -32,6 +34,7 @@ const Main: React.FC<MainProps> = (props) => {
   } else {
     return (
       <div className="uk-header">
+        <ErrorDisplay />
         <h3 className="uk-title uk-margin-remove-bottom no-tabs">
           {chrome.i18n.getMessage('content_msg_not_tab')}
         </h3>

--- a/src/js/components/main.tsx
+++ b/src/js/components/main.tsx
@@ -1,7 +1,6 @@
 import { model } from '../types/interface';
 import React, { useState } from 'react';
 import Block from './block';
-import { ErrorDisplay } from './error';
 
 interface MainProps {
   Block: model.Block[];
@@ -19,7 +18,6 @@ const Main: React.FC<MainProps> = (props) => {
   if (nowBlocks.length > 0) {
     return (
       <div>
-        <ErrorDisplay />
         {nowBlocks.map((block, index) => {
           return (
             <Block
@@ -34,7 +32,6 @@ const Main: React.FC<MainProps> = (props) => {
   } else {
     return (
       <div className="uk-header">
-        <ErrorDisplay />
         <h3 className="uk-title uk-margin-remove-bottom no-tabs">
           {chrome.i18n.getMessage('content_msg_not_tab')}
         </h3>

--- a/src/js/components/sideBar.tsx
+++ b/src/js/components/sideBar.tsx
@@ -3,11 +3,16 @@ import { blockService } from '../blockService';
 import { chromeService } from '../chromeService';
 
 const SideBar: React.FC = () => {
+  // エラー通知はerrorLogに統一する（ErrorDisplayがonChangedで即時表示する）
+  const notifyError = (error: unknown) => {
+    chromeService.errorLog.set(error).catch(console.error);
+  };
+
   const exportJson = () => {
     const exportTextElement = document.getElementById(
       'export_body'
     ) as HTMLInputElement;
-    blockService.exportAllDataJson(exportTextElement);
+    blockService.exportAllDataJson(exportTextElement).catch(notifyError);
   };
 
   const importJson = () => {
@@ -17,10 +22,10 @@ const SideBar: React.FC = () => {
     blockService
       .importAllDataJson(importTextElement.value)
       .catch((error) =>
-        alert(
+        notifyError(
           chrome.i18n.getMessage('content_msg_failed_import') +
-            '\n' +
-            error.message
+            ' ' +
+            (error instanceof Error ? error.message : String(error))
         )
       );
   };
@@ -33,7 +38,8 @@ const SideBar: React.FC = () => {
         .allClear()
         .then((_) =>
           alert(chrome.i18n.getMessage('content_msg_all_delete_finish'))
-        );
+        )
+        .catch(notifyError);
     }
   };
 

--- a/src/js/tabs.tsx
+++ b/src/js/tabs.tsx
@@ -7,6 +7,7 @@ import SideBar from './components/sideBar';
 import Header from './components/header';
 import React from 'react';
 import Main from './components/main';
+import { ErrorDisplay } from './components/error';
 import '../css/uikit.min.css';
 
 // @ts-ignore
@@ -16,12 +17,23 @@ window.onload = function () {
   const header = document.getElementById('header')!;
   ReactDOM.render(<Header />, header);
 
+  // エラー表示はブロック読み込みの成否に依存させず、どの導線で開いても
+  // 機能するようページ表示時点で独立してマウントする
+  const errorRoot = document.getElementById('error')!;
+  ReactDOM.render(<ErrorDisplay />, errorRoot);
+
   const sidebar = document.getElementById('sidebar')!;
   ReactDOM.render(<SideBar />, sidebar);
 
-  chromeService.storage.getAllBlock().then((blocks) => {
-    const main = document.getElementById('main')!;
+  chromeService.storage
+    .getAllBlock()
+    .then((blocks) => {
+      const main = document.getElementById('main')!;
 
-    ReactDOM.render(<Main Block={blocks} />, main);
-  });
+      ReactDOM.render(<Main Block={blocks} />, main);
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      chromeService.errorLog.set(message).catch(console.error);
+    });
 };

--- a/src/js/tabs.tsx
+++ b/src/js/tabs.tsx
@@ -33,7 +33,6 @@ window.onload = function () {
       ReactDOM.render(<Main Block={blocks} />, main);
     })
     .catch((error) => {
-      const message = error instanceof Error ? error.message : String(error);
-      chromeService.errorLog.set(message).catch(console.error);
+      chromeService.errorLog.set(error).catch(console.error);
     });
 };

--- a/src/tabs.html
+++ b/src/tabs.html
@@ -13,6 +13,12 @@
         </div>
       </div>
 
+      <div class="uk-grid">
+        <div class="uk-width-1-1">
+          <div id="error"></div>
+        </div>
+      </div>
+
       <div class="uk-grid main-contents">
         <div class="uk-width-expand" id="main"></div>
         <aside class="uk-width-auto" id="sidebar"></aside>


### PR DESCRIPTION
## 概要

Manifest V3 移行の PR 3/4。**base は #153（MV3 本体）のスタック PR**です。

MV2 では background で `alert()` によりエラーを通知していましたが、MV3 の service worker では DOM がなく使えません。#153 では暫定で `console.error` + バッジ「!」のみでしたが、この PR でエラー本文をユーザーが確認できるようにします。

## 変更内容

- **`chromeService.errorLog` を追加**: エラーメッセージを `chrome.storage.local` に保存し action バッジ「!」（赤）で通知。追加 permission 不要
- **`ErrorDisplay` コンポーネントを追加**（`src/js/components/error.tsx`）: tabs ページで保存済みエラーを UIkit の `uk-alert-danger` で表示。`storage.onChanged` を監視し、ページ表示中に発生したエラーも即時表示
  - どの導線（アクションクリック / コンテキストメニュー / URL 直打ち）で開いても表示されるよう、ブロック読み込みとは独立に `#error` へマウント
  - **ユーザーが実際にアラートを見た時点（可視ページに表示された時点）で保存とバッジをクリア**。裏で開いているページは表示のみで消費しないため、どの導線で後から開いても表示される。確認済みのアラートはリロードか×で消える
- **chromeService の reject を `Error` インスタンスに統一**（従来は `chrome.runtime.lastError` をそのまま reject しており、メッセージ抽出時に `[object Object]` になっていた）
- **background の `handleError` を errorLog 経由に変更**
- **tabs ページ内のエラー通知も errorLog に統一**: インポート失敗の `alert()` を置換、`setBlock` / `openAllTab` / エクスポート / 全削除 / `getAllBlock()` の catch 漏れ（unhandled rejection で silent failure）を修正。ページを開いたままでも `storage.onChanged` で即時表示される

## 検証

- テスト 26 件（errorLog の set / get / clear / lastError 時の reject、ErrorDisplay の表示・閉じる・クリア追随の計 10 件追加）/ lint / format:check / ビルドすべてパス

### 手動確認
1. SW コンソールで `chrome.storage.local.set({error:'test'})` を実行（または保存操作を大量に行い storage.sync のクォータ超過エラーを発生させる）
2. ツールバーにバッジ「!」が表示される
3. コンテキストメニューや URL 直打ちなど、どの導線で開いた tabs ページにも赤いアラートが表示される（表示中のページがあれば即時表示）
4. アラートを実際に見た（可視ページに表示された）時点でバッジが消え、裏の tabs ページの表示も取り下げられる
5. 確認後に再読み込みするとアラートは再表示されない（×で先に閉じることも可能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

