### PR TITLE
保存データとエクスポートJSONに保存時のバージョン情報を付与する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [NEW] 保存データ・エクスポート JSON に保存時のバージョン情報 (スキーマ版数・拡張機能バージョン) を付与 (#157)
+
 # v0.3.0 (2026-08-01)
 
 - [NEW] Manifest V3 に移行 (Chrome Web Store の MV2 廃止対応)

--- a/src/js/blockService.test.ts
+++ b/src/js/blockService.test.ts
@@ -283,8 +283,17 @@ describe('blockService', (): void => {
     expect(inflateSpy).toBeCalledTimes(1);
   });
 
-  test('inflateJson 未対応バージョンはエラー', (): void => {
+  test('inflateJson 未対応バージョンはエラー(圧縮)', (): void => {
     const input = '{"v":99,"ev":"99.0.0","d":"compressed-data"}';
+    expect(() => blockService.inflateJson(input, 1)).toThrow(
+      'Unsupported data version: v=99'
+    );
+    expect(inflateSpy).toBeCalledTimes(0);
+  });
+
+  test('inflateJson 未対応バージョンはエラー(非圧縮)', (): void => {
+    const input =
+      '{"v":99,"ev":"99.0.0","created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}';
     expect(() => blockService.inflateJson(input, 1)).toThrow(
       'Unsupported data version: v=99'
     );

--- a/src/js/blockService.test.ts
+++ b/src/js/blockService.test.ts
@@ -2,19 +2,27 @@
  * @jest-environment jsdom
  */
 import { blockService } from './blockService';
+import { chromeService } from './chromeService';
 import { zlibWrapper } from './zlib-wrapper';
 
 let deflateSpy: jest.SpyInstance;
 let inflateSpy: jest.SpyInstance;
+let versionSpy: jest.SpyInstance;
 
 beforeAll(() => {
   deflateSpy = jest.spyOn(zlibWrapper, 'deflate');
   inflateSpy = jest.spyOn(zlibWrapper, 'inflate');
+  versionSpy = jest.spyOn(chromeService.runtime, 'getExtensionVersion');
+});
+
+beforeEach(() => {
+  versionSpy.mockReturnValue('9.9.9');
 });
 
 afterEach(() => {
   deflateSpy.mockReset();
   inflateSpy.mockReset();
+  versionSpy.mockReset();
 });
 
 describe('blockService', (): void => {
@@ -128,7 +136,7 @@ describe('blockService', (): void => {
       ],
     };
     const expected =
-      '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}';
+      '{"v":2,"ev":"9.9.9","created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}';
     expect(blockService.deflateBlock(block)).toBe(expected);
     expect(deflateSpy.mock.calls[0]).toEqual([
       '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}',
@@ -164,7 +172,7 @@ describe('blockService', (): void => {
       ],
     };
     const expected =
-      'eNqkzNEKwjAMBdCvyaOiadPqo3P4G1JnmEJHxxrBz7e2cyAoA4VSetObA7YCxGZgJ3w+OkkB1G5tVlsiYzQZuwHcp6m4UyyfQBXkrdvgxwniRaSP+XlIh++u6z0vm9ClJByzW5yreJ7Wclq8CrZ+dj7aE92G0L7J+IUuxf9sNW8r9bOu53WtR53qdD8AAAD//w==';
+      '{"v":2,"ev":"9.9.9","d":"eNqkzNEKwjAMBdCvyaOiadPqo3P4G1JnmEJHxxrBz7e2cyAoA4VSetObA7YCxGZgJ3w+OkkB1G5tVlsiYzQZuwHcp6m4UyyfQBXkrdvgxwniRaSP+XlIh++u6z0vm9ClJByzW5yreJ7Wclq8CrZ+dj7aE92G0L7J+IUuxf9sNW8r9bOu53WtR53qdD8AAAD//w=="}';
     expect(blockService.deflateBlock(block)).toBe(expected);
     expect(deflateSpy.mock.calls[0]).toEqual([
       '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"},{"url":"http://google.com/test2","title":"google-test"},{"url":"http://google.com/test3","title":"google-test33"},{"url":"http://google.com/test4","title":"google-test44"}]}',
@@ -235,5 +243,150 @@ describe('blockService', (): void => {
     ]);
 
     expect(inflateSpy).toBeCalledTimes(1);
+  });
+
+  test('inflateJson v2非圧縮データ', (): void => {
+    const input =
+      '{"v":2,"ev":"0.3.0","created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}';
+    const expected = {
+      indexNum: 1,
+      createdAt: new Date(`2021-01-02T03:04:05.678Z`),
+      tabs: [
+        {
+          url: 'https://example.com/test',
+          title: 'title-test',
+        },
+      ],
+    };
+    expect(blockService.inflateJson(input, 1)).toStrictEqual(expected);
+    expect(inflateSpy).toBeCalledTimes(0);
+  });
+
+  test('inflateJson v2圧縮データ', (): void => {
+    inflateSpy.mockReturnValueOnce(
+      '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}'
+    );
+
+    const input = '{"v":2,"ev":"0.3.0","d":"compressed-data"}';
+    const expected = {
+      indexNum: 1,
+      createdAt: new Date(`2021-01-02T03:04:05.678Z`),
+      tabs: [
+        {
+          url: 'https://example.com/test',
+          title: 'title-test',
+        },
+      ],
+    };
+    expect(blockService.inflateJson(input, 1)).toStrictEqual(expected);
+    expect(inflateSpy.mock.calls[0]).toEqual(['compressed-data']);
+    expect(inflateSpy).toBeCalledTimes(1);
+  });
+
+  test('inflateJson 未対応バージョンはエラー', (): void => {
+    const input = '{"v":99,"ev":"99.0.0","d":"compressed-data"}';
+    expect(() => blockService.inflateJson(input, 1)).toThrow(
+      'Unsupported data version: v=99'
+    );
+    expect(inflateSpy).toBeCalledTimes(0);
+  });
+});
+
+describe('blockService import/export', (): void => {
+  let getAllBlockSpy: jest.SpyInstance;
+  let getTabLengthSpy: jest.SpyInstance;
+  let setBlockSpy: jest.SpyInstance;
+  let setTabLengthSpy: jest.SpyInstance;
+  const reload = jest.fn();
+
+  beforeEach(() => {
+    getAllBlockSpy = jest.spyOn(chromeService.storage, 'getAllBlock');
+    getTabLengthSpy = jest
+      .spyOn(chromeService.storage, 'getTabLength')
+      .mockResolvedValue(3);
+    setBlockSpy = jest
+      .spyOn(chromeService.storage, 'setBlock')
+      .mockResolvedValue(undefined);
+    setTabLengthSpy = jest
+      .spyOn(chromeService.storage, 'setTabLength')
+      .mockResolvedValue(undefined);
+    reload.mockClear();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = { tabs: { reload: reload } };
+  });
+
+  afterEach(() => {
+    getAllBlockSpy.mockRestore();
+    getTabLengthSpy.mockRestore();
+    setBlockSpy.mockRestore();
+    setTabLengthSpy.mockRestore();
+  });
+
+  test('exportAllDataJson バージョン情報付きで出力する', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([
+      {
+        indexNum: 0,
+        createdAt: new Date(`2021-01-02T03:04:05.678Z`),
+        tabs: [
+          {
+            url: 'https://example.com/test',
+            title: 'title-test',
+          },
+        ],
+      },
+    ]);
+    const element = { value: '' } as HTMLInputElement;
+
+    await blockService.exportAllDataJson(element);
+    expect(element.value).toBe(
+      '{"v":2,"ev":"9.9.9","blocks":[{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}]}'
+    );
+  });
+
+  test('importAllDataJson v2形式', async (): Promise<void> => {
+    const json =
+      '{"v":2,"ev":"0.3.0","blocks":[{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}]}';
+
+    await blockService.importAllDataJson(json);
+    expect(setBlockSpy).toHaveBeenCalledTimes(1);
+    expect(setBlockSpy.mock.calls[0][0]).toStrictEqual({
+      indexNum: 3,
+      createdAt: new Date(`2021-01-02T03:04:05.678Z`),
+      tabs: [
+        {
+          url: 'https://example.com/test',
+          title: 'title-test',
+        },
+      ],
+    });
+    expect(setTabLengthSpy).toHaveBeenCalledWith(4);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test('importAllDataJson v1形式(素の配列)', async (): Promise<void> => {
+    const json =
+      '[{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}]';
+
+    await blockService.importAllDataJson(json);
+    expect(setBlockSpy).toHaveBeenCalledTimes(1);
+    expect(setBlockSpy.mock.calls[0][0]).toStrictEqual({
+      indexNum: 3,
+      createdAt: new Date(`2021-01-02T03:04:05.678Z`),
+      tabs: [
+        {
+          url: 'https://example.com/test',
+          title: 'title-test',
+        },
+      ],
+    });
+    expect(setTabLengthSpy).toHaveBeenCalledWith(4);
+  });
+
+  test('importAllDataJson 未対応バージョンはエラー', async (): Promise<void> => {
+    await expect(
+      blockService.importAllDataJson('{"v":99,"blocks":[]}')
+    ).rejects.toThrow('Unsupported data version: v=99');
+    expect(setBlockSpy).not.toHaveBeenCalled();
+    expect(setTabLengthSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/js/blockService.test.ts
+++ b/src/js/blockService.test.ts
@@ -180,7 +180,7 @@ describe('blockService', (): void => {
     expect(deflateSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('inflateJson 非解凍時', (): void => {
+  test('inflateJson v1非圧縮データ(バージョン表記なし)', (): void => {
     inflateSpy.mockReturnValueOnce(
       '{"created_at":1627200615501,"tabs":[{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"},{"url":"chrome://extensions/","title":"拡張機能"},{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"},{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"},{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"},{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"},{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"},{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"},{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"},{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"},{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"},{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"},{"url":"chrome://newtab/","title":"新しいタブ"},{"url":"chrome-extension://djamgplmdfdnghbcpfgpbfadipbgihbi/tabs.html","title":"syncTabCliper"}]}'
     );
@@ -206,7 +206,7 @@ describe('blockService', (): void => {
     expect(inflateSpy).toBeCalledTimes(0);
   });
 
-  test('inflateJson 解凍', (): void => {
+  test('inflateJson v1圧縮データ(バージョン表記なし)', (): void => {
     inflateSpy.mockReturnValueOnce(
       '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"},{"url":"http://google.com/test2","title":"google-test"},{"url":"http://google.com/test3","title":"google-test33"},{"url":"http://google.com/test4","title":"google-test44"}]}'
     );
@@ -372,7 +372,7 @@ describe('blockService import/export', (): void => {
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  test('importAllDataJson v1形式(素の配列)', async (): Promise<void> => {
+  test('importAllDataJson v1形式(バージョン表記なしの素の配列)', async (): Promise<void> => {
     const json =
       '[{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}]';
 

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -85,17 +85,20 @@ export namespace blockService {
         throw e;
       }
     }
-    if (js.d == null) {
-      if (js.v == null || js.v === CURRENT_SCHEMA_VERSION) {
-        // 非圧縮のブロックJSON(vフィールドを持たないv1も構造は同じ)
+    // vフィールドを持たない従来形式は暗黙のv1
+    const version = js.v ?? 1;
+    switch (version) {
+      case 1:
+        // v1の非圧縮はブロックJSONそのもの
         return jsonObjToBlock(js, indexNum);
-      }
-      throw new Error(`Unsupported data version: v=${js.v}`);
+      case 2:
+        // v2は圧縮時のみエンベロープ形式({v, ev, d})になる
+        return js.d == null
+          ? jsonObjToBlock(js, indexNum)
+          : jsonToBlock(zlibWrapper.inflate(js.d), indexNum);
+      default:
+        throw new Error(`Unsupported data version: v=${version}`);
     }
-    if (js.v === CURRENT_SCHEMA_VERSION) {
-      return jsonToBlock(zlibWrapper.inflate(js.d), indexNum);
-    }
-    throw new Error(`Unsupported data version: v=${js.v}`);
   }
 
   // eslint-disable-next-line require-jsdoc
@@ -154,10 +157,14 @@ export namespace blockService {
     if (Array.isArray(json)) {
       // v1のエクスポートはブロックの素の配列
       blockObjs = json;
-    } else if (json.v === CURRENT_SCHEMA_VERSION) {
-      blockObjs = json.blocks;
     } else {
-      throw new Error(`Unsupported data version: v=${json.v}`);
+      switch (json.v) {
+        case 2:
+          blockObjs = json.blocks;
+          break;
+        default:
+          throw new Error(`Unsupported data version: v=${json.v}`);
+      }
     }
     const blocks = blockListForJsonObject(blockObjs, idx);
 

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -3,6 +3,10 @@ import { zlibWrapper } from './zlib-wrapper';
 import { chromeService } from './chromeService';
 
 export namespace blockService {
+  // 保存データ・エクスポートJSONのスキーマ版数
+  // バージョン情報を持たない従来形式を暗黙のv1とみなし、v2からフィールドを付与する
+  export const CURRENT_SCHEMA_VERSION = 2;
+
   // eslint-disable-next-line require-jsdoc
   export function createBlock(
     tabs: chrome.tabs.Tab[],
@@ -70,22 +74,39 @@ export namespace blockService {
 
   // eslint-disable-next-line require-jsdoc
   export function inflateJson(jsonStr: string, indexNum: number): model.Block {
+    let js: any;
     try {
-      return jsonToBlock(jsonStr, indexNum);
+      js = JSON.parse(jsonStr);
     } catch (e) {
       if (e instanceof SyntaxError) {
-        const jsonStr2 = zlibWrapper.inflate(jsonStr);
-        return jsonToBlock(jsonStr2, indexNum);
+        // v1の圧縮データは素のzlib+base64文字列でJSONとして解釈できない
+        return jsonToBlock(zlibWrapper.inflate(jsonStr), indexNum);
       } else {
         throw e;
       }
     }
+    if (js.d == null) {
+      // 非圧縮のブロックJSON(vフィールドを持たないv1も構造は同じ)
+      return jsonObjToBlock(js, indexNum);
+    }
+    if (js.v === CURRENT_SCHEMA_VERSION) {
+      return jsonToBlock(zlibWrapper.inflate(js.d), indexNum);
+    }
+    throw new Error(`Unsupported data version: v=${js.v}`);
   }
 
   // eslint-disable-next-line require-jsdoc
   export function deflateBlock(block: model.Block): string {
-    const blockStr = blockToJson(block);
-    const deflateStr = zlibWrapper.deflate(blockStr);
+    // 圧縮アルゴリズムの変更に備え、バージョン情報は圧縮ペイロードの外側に置く
+    const version = {
+      v: CURRENT_SCHEMA_VERSION,
+      ev: chromeService.runtime.getExtensionVersion(),
+    };
+    const blockStr = JSON.stringify({ ...version, ...blockToJsonObj(block) });
+    const deflateStr = JSON.stringify({
+      ...version,
+      d: zlibWrapper.deflate(blockToJson(block)),
+    });
     if (deflateStr.length < blockStr.length) {
       return deflateStr;
     } else {
@@ -98,7 +119,11 @@ export namespace blockService {
     targetElement: HTMLInputElement
   ): Promise<void> {
     return chromeService.storage.getAllBlock().then((blocks) => {
-      targetElement.value = JSON.stringify(blocks.map(blockToJsonObj));
+      targetElement.value = JSON.stringify({
+        v: CURRENT_SCHEMA_VERSION,
+        ev: chromeService.runtime.getExtensionVersion(),
+        blocks: blocks.map(blockToJsonObj),
+      });
     });
   }
 
@@ -122,14 +147,23 @@ export namespace blockService {
     const idx = tabLength;
 
     const json = JSON.parse(jsonStr);
-    const blocks = blockListForJsonObject(json, idx);
+    let blockObjs: object[];
+    if (Array.isArray(json)) {
+      // v1のエクスポートはブロックの素の配列
+      blockObjs = json;
+    } else if (json.v === CURRENT_SCHEMA_VERSION) {
+      blockObjs = json.blocks;
+    } else {
+      throw new Error(`Unsupported data version: v=${json.v}`);
+    }
+    const blocks = blockListForJsonObject(blockObjs, idx);
 
     blocks.forEach((block) => {
       promiseArray.push(chromeService.storage.setBlock(block));
     });
 
     await Promise.all(promiseArray);
-    await chromeService.storage.setTabLength(tabLength + json.length);
+    await chromeService.storage.setTabLength(tabLength + blockObjs.length);
     chrome.tabs.reload({ bypassCache: true });
   }
 }

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -86,8 +86,11 @@ export namespace blockService {
       }
     }
     if (js.d == null) {
-      // 非圧縮のブロックJSON(vフィールドを持たないv1も構造は同じ)
-      return jsonObjToBlock(js, indexNum);
+      if (js.v == null || js.v === CURRENT_SCHEMA_VERSION) {
+        // 非圧縮のブロックJSON(vフィールドを持たないv1も構造は同じ)
+        return jsonObjToBlock(js, indexNum);
+      }
+      throw new Error(`Unsupported data version: v=${js.v}`);
     }
     if (js.v === CURRENT_SCHEMA_VERSION) {
       return jsonToBlock(zlibWrapper.inflate(js.d), indexNum);

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -220,6 +220,16 @@ export namespace chromeService {
     }
   }
 
+  export namespace runtime {
+    /**
+     * 拡張機能自体のバージョン(manifestのversion)を返す
+     * @return {string} 拡張機能のバージョン文字列
+     */
+    export function getExtensionVersion(): string {
+      return chrome.runtime.getManifest().version;
+    }
+  }
+
   export namespace errorLog {
     export const errorKey = 'error';
 


### PR DESCRIPTION
## 概要

Closes #157

`chrome.storage.sync` に保存するブロックデータとエクスポート JSON に、保存時のバージョン情報を付与します。

- **スキーマ版数 `v`**(整数): データ形式の版。読み込み時の分岐に使用。従来のバージョン情報なし形式を暗黙の v1 とみなし、今回から `v: 2` を付与
- **拡張機能バージョン `ev`**(文字列): 保存時の manifest version。どの版が書いたデータかの追跡用

## 形式

将来の圧縮アルゴリズム変更に備え、バージョン情報は圧縮ペイロードの**外側**に置いています(中に入れると解凍方法を決める前に解凍が必要になるため)。

- ストレージ非圧縮時: `{"v":2,"ev":"0.3.0","created_at":...,"tabs":[...]}`
- ストレージ圧縮時: `{"v":2,"ev":"0.3.0","d":"<zlib+base64>"}`
- エクスポート: `{"v":2,"ev":"0.3.0","blocks":[...]}`

## 後方互換性

- 既存の保存データ(素の JSON / 素の zlib+base64)はそのまま読み込み可能。再保存時に自然に v2 へ移行
- 旧形式のエクスポート JSON(素の配列)も引き続きインポート可能
- 未知のバージョンはエラーにして既存のエラー通知経路で表示

## テスト

- `npm test` 37件 pass(v1/v2 の読み書き・インポート/エクスポート・未対応バージョンのエラーを追加)
- `npm run lint` / `npm run format:check` / `npm run build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)