### PR TITLE
CIのactionsを最新化 (checkout v7, setup-node v7)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .node-version
           cache: npm


### PR DESCRIPTION
## 概要
- `actions/checkout` を v4 → v7 に更新
- `actions/setup-node` を v4 → v7 に更新

## 破壊的変更の確認
- setup-node v5: node24 ランタイム必須 → GitHub ホストランナー (ubuntu-latest) なので影響なし
- setup-node v6: 自動キャッシュが npm のみに限定 → 本リポジトリは `cache: npm` を明示指定しており影響なし
- setup-node v7 / checkout v5-v7: 本ワークフローの使い方に影響する変更なし

## 動作確認
このブランチの push で CI test が成功済み（format check / lint / test / build:prod すべて通過）
https://github.com/ik11235/SyncTabClipper/actions/runs/30695796113

🤖 Generated with [Claude Code](https://claude.com/claude-code)