### PR TITLE
sideBarの生DOM操作をReactのstate/refに置き換え

### DIFF
--- a/src/js/blockService.test.ts
+++ b/src/js/blockService.test.ts
@@ -348,10 +348,7 @@ describe('blockService import/export', (): void => {
         ],
       },
     ]);
-    const element = { value: '' } as HTMLInputElement;
-
-    await blockService.exportAllDataJson(element);
-    expect(element.value).toBe(
+    await expect(blockService.exportAllDataJson()).resolves.toBe(
       '{"v":2,"ev":"9.9.9","blocks":[{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}]}',
     );
   });

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -121,16 +121,14 @@ export namespace blockService {
     }
   }
 
-  export function exportAllDataJson(
-    targetElement: HTMLInputElement,
-  ): Promise<void> {
-    return chromeService.storage.getAllBlock().then((blocks) => {
-      targetElement.value = JSON.stringify({
+  export function exportAllDataJson(): Promise<string> {
+    return chromeService.storage.getAllBlock().then((blocks) =>
+      JSON.stringify({
         v: CURRENT_SCHEMA_VERSION,
         ev: chromeService.runtime.getExtensionVersion(),
         blocks: blocks.map(blockToJsonObj),
-      });
-    });
+      }),
+    );
   }
 
   function blockListForJsonObject(

--- a/src/js/components/sideBar.tsx
+++ b/src/js/components/sideBar.tsx
@@ -1,26 +1,23 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { blockService } from '../blockService';
 import { chromeService } from '../chromeService';
 
 const SideBar: React.FC = () => {
+  const [exportText, setExportText] = useState('');
+  const importRef = useRef<HTMLTextAreaElement>(null);
+
   // エラー通知はerrorLogに統一する（ErrorDisplayがonChangedで即時表示する）
   const notifyError = (error: unknown) => {
     chromeService.errorLog.set(error).catch(console.error);
   };
 
   const exportJson = () => {
-    const exportTextElement = document.getElementById(
-      'export_body',
-    ) as HTMLInputElement;
-    blockService.exportAllDataJson(exportTextElement).catch(notifyError);
+    blockService.exportAllDataJson().then(setExportText).catch(notifyError);
   };
 
   const importJson = () => {
-    const importTextElement = document.getElementById(
-      'import_body',
-    ) as HTMLInputElement;
     blockService
-      .importAllDataJson(importTextElement.value)
+      .importAllDataJson(importRef.current!.value)
       .catch((error) =>
         notifyError(
           chrome.i18n.getMessage('content_msg_failed_import') +
@@ -73,7 +70,12 @@ const SideBar: React.FC = () => {
             <ul className="uk-nav-sub">
               <li>
                 <label htmlFor="export_body" />
-                <textarea readOnly={true} id="export_body" rows={4} />
+                <textarea
+                  readOnly={true}
+                  id="export_body"
+                  rows={4}
+                  value={exportText}
+                />
               </li>
               <li>
                 <button id="export_link" onClick={exportJson}>
@@ -93,7 +95,7 @@ const SideBar: React.FC = () => {
             <ul className="uk-nav-sub">
               <li>
                 <label htmlFor="import_body" />
-                <textarea id="import_body" rows={4} />
+                <textarea id="import_body" rows={4} ref={importRef} />
               </li>
               <li>
                 <button id="import_link" onClick={importJson}>


### PR DESCRIPTION
## 概要

#158 の第1段。sideBar コンポーネントに残っていた生 DOM 操作を React の宣言的なデータフローに置き換える。

- `blockService.exportAllDataJson` を、DOM 要素を受け取って `value` に代入する副作用設計から **JSON 文字列を返す純粋な関数**（`Promise<string>`）に変更
- sideBar の export 用 textarea を controlled 化（`useState`）
- import 用 textarea を `useRef<HTMLTextAreaElement>` で参照（`getElementById` + `as HTMLInputElement` の型の嘘を解消）
- テストのダミー要素（`{ value: '' } as HTMLInputElement`）を廃止し、戻り値を assert する形に変更

## 検証

- `npm run format:check && npm run lint && npm test && npm run build:prod` すべてパス（38 tests passed）

refs #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)