### PR TITLE
tabsページを単一Reactルートに統合

### DIFF
--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import App from './app';
+import { chromeService } from '../chromeService';
+
+// テスティングライブラリを介さず素のactを使うため必要
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('App', (): void => {
+  let localData: { [key: string]: string };
+  let onChangedListeners: Array<
+    (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string,
+    ) => void
+  >;
+  let container: HTMLDivElement;
+  let root: Root;
+  let getAllBlockSpy: jest.SpyInstance;
+
+  const mount = async (): Promise<void> => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+  };
+
+  beforeEach((): void => {
+    localData = {};
+    onChangedListeners = [];
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    getAllBlockSpy = jest.spyOn(chromeService.storage, 'getAllBlock');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      runtime: {
+        getManifest: () => ({ name: 'SyncTabClipper', version: '9.9.9' }),
+      },
+      i18n: {
+        getMessage: (key: string): string => key,
+      },
+      storage: {
+        local: {
+          set: (obj: { [key: string]: string }, cb: () => void): void => {
+            Object.assign(localData, obj);
+            cb();
+            // 実際のChromeと同様に、変更をonChangedリスナーへ通知する
+            for (const listener of onChangedListeners) {
+              const changes: { [key: string]: chrome.storage.StorageChange } =
+                {};
+              for (const key of Object.keys(obj)) {
+                changes[key] = { newValue: obj[key] };
+              }
+              listener(changes, 'local');
+            }
+          },
+          get: (
+            keys: string[],
+            cb: (items: { [key: string]: string }) => void,
+          ): void => {
+            const res: { [key: string]: string } = {};
+            for (const key of keys) {
+              const value = localData[key];
+              if (value != null) {
+                res[key] = value;
+              }
+            }
+            cb(res);
+          },
+          remove: (key: string, cb: () => void): void => {
+            delete localData[key];
+            cb();
+          },
+        },
+        onChanged: {
+          addListener: (
+            listener: (
+              changes: { [key: string]: chrome.storage.StorageChange },
+              areaName: string,
+            ) => void,
+          ): void => {
+            onChangedListeners.push(listener);
+          },
+          removeListener: jest.fn(),
+        },
+      },
+      action: {
+        setBadgeText: jest.fn(),
+        setBadgeBackgroundColor: jest.fn(),
+      },
+    };
+  });
+
+  afterEach((): void => {
+    act(() => root.unmount());
+    container.remove();
+    getAllBlockSpy.mockRestore();
+  });
+
+  test('ブロック読み込み成功時はタブの一覧を描画する', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([
+      {
+        indexNum: 0,
+        createdAt: new Date('2021-01-02T03:04:05.678Z'),
+        tabs: [{ url: 'https://example.com/test', title: 'title-test' }],
+      },
+    ]);
+
+    await mount();
+
+    expect(container.textContent).toContain('SyncTabClipper');
+    expect(container.textContent).toContain('title-test');
+    expect(container.textContent).toContain('content_msg_menu');
+  });
+
+  test('ブロックが空のときは未保存メッセージを表示する', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([]);
+
+    await mount();
+
+    expect(container.textContent).toContain('content_msg_not_tab');
+  });
+
+  test('ブロック読み込み失敗時もエラー表示は機能する', async (): Promise<void> => {
+    getAllBlockSpy.mockRejectedValue(new Error('load failed'));
+
+    await mount();
+
+    expect(container.textContent).toContain('load failed');
+    // ヘッダーとサイドバーは読み込み失敗と無関係に描画される
+    expect(container.textContent).toContain('SyncTabClipper');
+    expect(container.textContent).toContain('content_msg_menu');
+  });
+});

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -136,4 +136,30 @@ describe('App', (): void => {
     expect(container.textContent).toContain('SyncTabClipper');
     expect(container.textContent).toContain('content_msg_menu');
   });
+
+  test('Mainのレンダリング時例外でもページ全体は生き残りエラーを表示する', async (): Promise<void> => {
+    // createdAtが不正なDateだとblock.tsxのtoISOString()がRangeErrorを投げる
+    getAllBlockSpy.mockResolvedValue([
+      {
+        indexNum: 0,
+        createdAt: new Date('invalid'),
+        tabs: [{ url: 'https://example.com/test', title: 'title-test' }],
+      },
+    ]);
+    // Reactが境界で捕捉した例外をconsole.errorへ出力するため抑止する
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    try {
+      await mount();
+
+      // ヘッダー・サイドバーはアンマウントされず、エラーが表示される
+      expect(container.textContent).toContain('SyncTabClipper');
+      expect(container.textContent).toContain('content_msg_menu');
+      expect(container.textContent).toContain('Invalid time value');
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
 });

--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { model } from '../types/interface';
+import { chromeService } from '../chromeService';
+import Header from './header';
+import { ErrorDisplay } from './error';
+import Main from './main';
+import SideBar from './sideBar';
+
+const App: React.FC = () => {
+  // ロード完了までMainをマウントしない（nullはロード中を表す）。
+  // Mainはpropsを初期値としてstateに取り込むため、常にロード済みの
+  // データでマウントされる必要がある
+  const [blocks, setBlocks] = useState<model.Block[] | null>(null);
+
+  useEffect(() => {
+    chromeService.storage
+      .getAllBlock()
+      .then(setBlocks)
+      .catch((error) => {
+        chromeService.errorLog.set(error).catch(console.error);
+      });
+  }, []);
+
+  return (
+    <div className="uk-container">
+      <div className="uk-grid">
+        <div className="uk-width-1-1">
+          <Header />
+        </div>
+      </div>
+
+      {/* エラー表示はブロック読み込みの成否に依存させず常にレンダリングする */}
+      <div className="uk-grid">
+        <div className="uk-width-1-1">
+          <ErrorDisplay />
+        </div>
+      </div>
+
+      <div className="uk-grid">
+        <div className="uk-width-expand">
+          {blocks != null && <Main Block={blocks} />}
+        </div>
+        <SideBar />
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -3,6 +3,7 @@ import { model } from '../types/interface';
 import { chromeService } from '../chromeService';
 import Header from './header';
 import { ErrorDisplay } from './error';
+import { ErrorBoundary } from './errorBoundary';
 import Main from './main';
 import SideBar from './sideBar';
 
@@ -38,7 +39,12 @@ const App: React.FC = () => {
 
       <div className="uk-grid">
         <div className="uk-width-expand">
-          {blocks != null && <Main Block={blocks} />}
+          {/* Mainのレンダリング時例外でHeader/ErrorDisplay/SideBarまで
+              アンマウントされないよう境界で隔離する（旧・独立ルート構成が
+              持っていたフォールトアイソレーションの維持） */}
+          <ErrorBoundary>
+            {blocks != null && <Main Block={blocks} />}
+          </ErrorBoundary>
         </div>
         <SideBar />
       </div>

--- a/src/js/components/errorBoundary.tsx
+++ b/src/js/components/errorBoundary.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { chromeService } from '../chromeService';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * 子のレンダリング時例外がページ全体を巻き込んでアンマウントするのを防ぐ。
+ * 捕捉した例外はerrorLogへ保存し、表示はErrorDisplayに任せる
+ */
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown): void {
+    chromeService.errorLog.set(error).catch(console.error);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return null;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/js/components/sideBar.tsx
+++ b/src/js/components/sideBar.tsx
@@ -46,6 +46,8 @@ const SideBar: React.FC = () => {
   return (
     <aside className="uk-width-auto">
       <div className="uk-card uk-card-default uk-card-body">
+        {/* uk-nav/uk-iconはReact管理下のノードを削除しないため共存できる。
+            uk-alertのようにノード自体を削除するUIkitコンポーネントは不可 */}
         <ul
           className="uk-nav-default uk-nav-parent-icon"
           data-uk-nav="multiple: true"

--- a/src/js/tabs.tsx
+++ b/src/js/tabs.tsx
@@ -1,35 +1,10 @@
 import UIkit from 'uikit';
 import Icons from 'uikit/dist/js/uikit-icons';
-import { chromeService } from './chromeService';
 import { createRoot } from 'react-dom/client';
-import SideBar from './components/sideBar';
-import Header from './components/header';
-import Main from './components/main';
-import { ErrorDisplay } from './components/error';
+import App from './components/app';
 import '../css/uikit.min.css';
 
 UIkit.use(Icons);
 
-window.onload = function () {
-  const header = document.getElementById('header')!;
-  createRoot(header).render(<Header />);
-
-  // エラー表示はブロック読み込みの成否に依存させず、どの導線で開いても
-  // 機能するようページ表示時点で独立してマウントする
-  const errorRoot = document.getElementById('error')!;
-  createRoot(errorRoot).render(<ErrorDisplay />);
-
-  const sidebar = document.getElementById('sidebar')!;
-  createRoot(sidebar).render(<SideBar />);
-
-  chromeService.storage
-    .getAllBlock()
-    .then((blocks) => {
-      const main = document.getElementById('main')!;
-
-      createRoot(main).render(<Main Block={blocks} />);
-    })
-    .catch((error) => {
-      chromeService.errorLog.set(error).catch(console.error);
-    });
-};
+// scriptはdefer読み込みのため、実行時点で#rootは必ず存在する
+createRoot(document.getElementById('root')!).render(<App />);

--- a/src/tabs.html
+++ b/src/tabs.html
@@ -3,28 +3,9 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <title>syncTabCliper</title>
-    <script src="js/tabs.js"></script>
+    <script src="js/tabs.js" defer></script>
   </head>
   <body>
-    <div class="uk-container">
-      <div class="uk-grid">
-        <div class="uk-width-1-1">
-          <div id="header"></div>
-        </div>
-      </div>
-
-      <div class="uk-grid">
-        <div class="uk-width-1-1">
-          <div id="error"></div>
-        </div>
-      </div>
-
-      <div class="uk-grid main-contents">
-        <div class="uk-width-expand" id="main"></div>
-        <aside class="uk-width-auto" id="sidebar"></aside>
-      </div>
-    </div>
-
-    <div id="footer"></div>
+    <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
## 概要

#158 の第2段（最終段）。4つの独立 React ルート（`#header` / `#error` / `#main` / `#sidebar`）を廃止し、ページ全体を単一の React ツリーでレンダリングする。

- **新規 `App` コンポーネント**: `tabs.html` にあった UIkit グリッドレイアウトを JSX に移植。`getAllBlock()` の呼び出しも `useEffect` に移動
- **`tabs.html` のミニマル化**: `<div id="root">` のみに。script は `defer` 化し `window.onload` を廃止
- Main は `getAllBlock()` 完了までマウントしない（props を初期値として state に取り込む既存パターンを壊さないため）
- ErrorDisplay はブロック読み込みの成否と無関係に常時レンダリングし、「読み込み失敗でもエラー表示が機能する」既存の意図を維持（回帰テストあり）
- `tabs.html` 側と sideBar.tsx 側で二重になっていた `<aside>` は移行で自然解消
- 未参照の `#footer`、CSS 定義のない `main-contents` クラスは移植しない
- UIkit の `data-uk-nav` / `data-uk-icon` は現状維持（React 管理下のノードを削除しないため共存可。`data-uk-alert` 問題とは別クラス）。判断コメントを sideBar.tsx に追記

## テスト

- 新規 `app.test.tsx`（error.test.tsx のパターン踏襲、@testing-library 不使用）: 読み込み成功 / 空 / 失敗時のエラー表示の3ケース
- `npm run format:check && npm run lint && npm test && npm run build:prod` すべてパス（41 tests）

## 手動確認の観点

- サイドバーのアコーディオン開閉（data-uk-nav）とアイコンの SVG 化（data-uk-icon）
- タブ個別クリック / すべて開く / すべて閉じる / 全削除 / エクスポート / インポート
- 不正 JSON インポートでエラーアラート表示 → × で閉じる

closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)