### PR TITLE
v0.3.1 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# Unreleased
+# v0.3.1 (2026-08-01)
 
 - [NEW] 保存データ・エクスポート JSON に保存時のバージョン情報 (スキーマ版数・拡張機能バージョン) を付与 (#157)
+- [UPDATE] uikit.css の ver を 3.25.20 に更新
+- [DEV] React 19 / TypeScript 5.9 / eslint 9 / jest 30 / webpack プラグイン群など開発依存を最新化し、npm audit の high 脆弱性を解消
+- [DEV] CI の Node を 24 に更新し、GitHub Actions を最新化
 
 # v0.3.0 (2026-08-01)
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SyncTabClipper",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "manifest_version": 3,
   "description": "__MSG_Description__",
   "default_locale": "en",


### PR DESCRIPTION
## 概要

v0.3.0 → master の差分を v0.3.1 としてリリースする準備です。

- `src/manifest.json` の version を 0.3.1 に更新
- CHANGELOG の Unreleased を v0.3.1 (2026-08-01) として確定し、v0.3.0 以降の変更を追記

## v0.3.1 に含まれる変更

- [NEW] 保存データ・エクスポート JSON に保存時のバージョン情報を付与 (#157 / #160)
- [UPDATE] uikit を 3.25.20 に更新 (#170)
- [DEV] React 19 / TypeScript 5.9 / eslint 9 / jest 30 / webpack プラグイン群の更新、npm audit high 解消 (#161, #164, #165, #169)
- [DEV] CI の Node 24 化・actions 最新化 (#159, #162)
- README 整備 (#172)

🤖 Generated with [Claude Code](https://claude.com/claude-code)