### PR TITLE
サイドバーのエクスポート・インポート項目の文字色を削除項目と揃える

### DIFF
--- a/src/js/components/sideBar.tsx
+++ b/src/js/components/sideBar.tsx
@@ -59,7 +59,7 @@ const SideBar: React.FC = () => {
               {chrome.i18n.getMessage('content_msg_all_data_delete')}
             </a>
           </li>
-          <li className="uk-parent">
+          <li className="uk-parent uk-active">
             <a href="#">
               <span
                 className="uk-margin-small-right"
@@ -84,7 +84,7 @@ const SideBar: React.FC = () => {
               </li>
             </ul>
           </li>
-          <li className="uk-parent">
+          <li className="uk-parent uk-active">
             <a href="#">
               <span
                 className="uk-margin-small-right"


### PR DESCRIPTION
## 概要
サイドバーメニューで「すべてのデータを削除する」だけ濃い文字色になり、エクスポート・インポートが薄く見えていたのを統一する。

## 原因
UIkitの `.uk-nav-default` では `uk-active` 付きの項目のみリンク色が #333 になり、それ以外は #999 になる。React化コミット a5e8f07 以来、削除項目の `<li>` にだけ `uk-active` が付いていた。

## 変更内容
- エクスポート・インポートの `<li className="uk-parent">` に `uk-active` を追加し、3項目とも同じ色にする

## 確認
- `tsc --noEmit` / ESLint パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)