### PR TITLE
タブのURL・タイトルの二重エスケープを解消しescapeHtmlを削除

### DIFF
--- a/src/js/components/tab.test.tsx
+++ b/src/js/components/tab.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { Tab } from './tab';
+
+// テスティングライブラリを介さず素のactを使うため必要
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('Tab', (): void => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const mount = async (tab: {
+    url: string;
+    title: string;
+  }): Promise<void> => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Tab tab={tab} deleteClick={jest.fn()} openLinkClick={jest.fn()} />,
+      );
+    });
+  };
+
+  beforeEach((): void => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach((): void => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  test('タイトルとURLをそのまま表示する', async (): Promise<void> => {
+    await mount({
+      url: 'https://example.com/',
+      title: 'example title',
+    });
+
+    const link = container.querySelector<HTMLAnchorElement>('a.tab_link')!;
+    expect(link.textContent).toBe('example title');
+    expect(link.getAttribute('href')).toBe('https://example.com/');
+  });
+
+  test('&を含むタイトルとURLを二重エスケープせず表示する', async (): Promise<void> => {
+    await mount({
+      url: 'https://example.com/?a=1&b=2',
+      title: 'A & B',
+    });
+
+    const link = container.querySelector<HTMLAnchorElement>('a.tab_link')!;
+    expect(link.textContent).toBe('A & B');
+    expect(link.getAttribute('href')).toBe('https://example.com/?a=1&b=2');
+    expect(link.getAttribute('data-url')).toBe('https://example.com/?a=1&b=2');
+    expect(link.getAttribute('data-title')).toBe('A & B');
+  });
+});

--- a/src/js/components/tab.test.tsx
+++ b/src/js/components/tab.test.tsx
@@ -14,10 +14,7 @@ describe('Tab', (): void => {
   let container: HTMLDivElement;
   let root: Root;
 
-  const mount = async (tab: {
-    url: string;
-    title: string;
-  }): Promise<void> => {
+  const mount = async (tab: { url: string; title: string }): Promise<void> => {
     await act(async () => {
       root = createRoot(container);
       root.render(

--- a/src/js/components/tab.tsx
+++ b/src/js/components/tab.tsx
@@ -11,26 +11,24 @@ interface TabProps {
 export const Tab: React.FC<TabProps> = (props) => {
   const domain = util.getDomain(props.tab.url);
   const encodeDomain = domain === '' ? encodeURI(' ') : encodeURI(domain);
-  const encodeUrl = util.escapeHtml(props.tab.url);
-  const encodeTitle = util.escapeHtml(props.tab.title);
 
   return (
     <li className="tab-root-dom">
       <img
         src={`https://www.google.com/s2/favicons?domain=${encodeDomain}`}
-        alt={encodeTitle}
+        alt={props.tab.title}
       />
       <a
-        href={encodeUrl}
+        href={props.tab.url}
         className="tab_link"
-        data-url={encodeUrl}
-        data-title={encodeTitle}
+        data-url={props.tab.url}
+        data-title={props.tab.title}
         onClick={(e) => {
           e.preventDefault();
           props.openLinkClick();
         }}
       >
-        {encodeTitle}
+        {props.tab.title}
       </a>
       <span
         className="uk-link tab_close"

--- a/src/js/util.test.ts
+++ b/src/js/util.test.ts
@@ -10,11 +10,6 @@ describe('util', (): void => {
     expect(res).toBe('');
   });
 
-  test('escape_html 正常系', (): void => {
-    const res = util.escapeHtml('<html>aaa</html>');
-    expect(res).toBe('&lt;html&gt;aaa&lt;/html&gt;');
-  });
-
   test('toNumber 正常系string', (): void => {
     const res = util.toNumber('123');
     expect(res).toBe(123);

--- a/src/js/util.ts
+++ b/src/js/util.ts
@@ -20,27 +20,6 @@ export namespace util {
   }
 
   /**
-   * HTMLの特殊文字をエスケープして返す
-   * https://qiita.com/saekis/items/c2b41cd8940923863791
-   *
-   * @param {string} string htmlとしてエスケープしたい文字列
-   * @return {string} エスケープした文字列
-   */
-  export function escapeHtml(string: string): string {
-    // @ts-expect-error 置換マップの戻り値がstring | undefinedと推論されるため
-    return string.replace(/[&'`"<>]/g, function (match) {
-      return {
-        '&': '&amp;',
-        "'": '&#x27;',
-        '`': '&#x60;',
-        '"': '&quot;',
-        '<': '&lt;',
-        '>': '&gt;',
-      }[match];
-    });
-  }
-
-  /**
    * 渡された文字列をNumberに変換する
    * 変換できない場合、例外を出力
    *


### PR DESCRIPTION
## 概要
closes #176

`src/js/components/tab.tsx` でタブのURLとタイトルに `util.escapeHtml()` を適用した値をJSXに渡していたため、Reactの自動エスケープと二重になり `A & B` が `A &amp; B` と表示され、`href` のURLも `?a=1&b=2` → `?a=1&amp;b=2` のように壊れていました。

## 変更内容
- `tab.tsx` で `util.escapeHtml()` の適用をやめ、`props.tab.url` / `props.tab.title` をそのままJSXに渡すよう修正
- `escapeHtml` の使用箇所が他に残っていないことを確認したうえで、`util.escapeHtml` 関数本体と `util.test.ts` の対応テストを削除
- `tab.test.tsx` を新規追加し、`&` を含むタイトル/URLが二重エスケープされずそのまま表示されることを検証

## 動作確認
- `npm test`（43件 pass）
- `npm run lint`
- `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)