### PR TITLE
blockコンポーネントの未評価テンプレートリテラルが残るdata-created-at属性を削除

### DIFF
--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -68,10 +68,7 @@ const Block: React.FC<BlockProps> = (props) => {
   };
 
   return (
-    <div
-      className="tabs uk-card-default block-root-dom"
-      data-created-at="${created_at.getTime()}"
-    >
+    <div className="tabs uk-card-default block-root-dom">
       <div className="uk-card-header">
         <h3 className="uk-card-title uk-margin-remove-bottom">
           {chrome.i18n.getMessage('content_msg_tab_length', [


### PR DESCRIPTION
closes #175

## 概要
`src/js/components/block.tsx` のルート div に `data-created-at="${created_at.getTime()}"` がテンプレートリテラル未評価のまま文字列リテラルとして出力されていたため、属性ごと削除しました。

## 調査結果と判断根拠
`src/` 配下を `data-created-at` / `dataset` / `getAttribute` / `createdAt` で grep して参照有無を確認しました。

- `data-created-at` の出現は block.tsx の当該行（バグ行そのもの）の1箇所のみ
- `dataset.createdAt` や `getAttribute` による属性読み取りは `src/` 内に存在しない
- `createdAt` の利用はいずれも Block オブジェクトのプロパティ経由（`blockService.ts` の serialize/deserialize、`chromeService.ts` のソート、block.tsx の `<time>` 表示）であり、DOM 属性を参照するコードはない

生DOM操作時代の名残で参照が存在しないため、issue の方針どおり修正ではなく属性の削除を選択しました。なお、当該行の `created_at` という変数は block.tsx に存在せず（実際の変数は `createdAt`）、仮に評価されていてもエラーになるコードでした。

## 動作確認
- `npm test`: 6 suites / 42 tests 全て pass
- `npm run lint`: エラーなし
- `npm run build`: webpack compiled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)