### PR TITLE
ブロック一覧のstateをAppに持ち上げてchrome.storageを単一の情報源にする

### DIFF
--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -160,6 +160,42 @@ describe('App', (): void => {
     }
   });
 
+  test('全データ削除時はAppのstateが空になり未保存メッセージを表示する', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([
+      {
+        indexNum: 0,
+        createdAt: new Date('2021-01-02T03:04:05.678Z'),
+        tabs: [{ url: 'https://example.com/test', title: 'title-test' }],
+      },
+    ]);
+    const allClearSpy = jest
+      .spyOn(chromeService.storage, 'allClear')
+      .mockResolvedValue(undefined);
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    const alertSpy = jest
+      .spyOn(window, 'alert')
+      .mockImplementation(() => undefined);
+
+    try {
+      await mount();
+      expect(container.textContent).toContain('title-test');
+
+      const allClearLink = container.querySelector('#all_clear') as HTMLElement;
+      await act(async () => {
+        allClearLink.click();
+      });
+
+      // storageが全削除され、一覧も空表示に切り替わる
+      expect(allClearSpy).toHaveBeenCalled();
+      expect(container.textContent).not.toContain('title-test');
+      expect(container.textContent).toContain('content_msg_not_tab');
+    } finally {
+      allClearSpy.mockRestore();
+      confirmSpy.mockRestore();
+      alertSpy.mockRestore();
+    }
+  });
+
   test('ブロック読み込み失敗時もエラー表示は機能する', async (): Promise<void> => {
     getAllBlockSpy.mockRejectedValue(new Error('load failed'));
 

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -126,6 +126,40 @@ describe('App', (): void => {
     expect(container.textContent).toContain('content_msg_not_tab');
   });
 
+  test('ブロック削除時はAppのstateが更新され一覧から消える', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([
+      {
+        indexNum: 0,
+        createdAt: new Date('2021-01-02T03:04:05.678Z'),
+        tabs: [{ url: 'https://example.com/test', title: 'title-test' }],
+      },
+    ]);
+    const setBlockSpy = jest
+      .spyOn(chromeService.storage, 'setBlock')
+      .mockResolvedValue(undefined);
+
+    try {
+      await mount();
+      expect(container.textContent).toContain('title-test');
+
+      const deleteLink = container.querySelector(
+        '.all_tab_delete',
+      ) as HTMLElement;
+      await act(async () => {
+        deleteLink.click();
+      });
+
+      // storageへ空タブのブロックとして永続化され、一覧からも消える
+      expect(setBlockSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ indexNum: 0, tabs: [] }),
+      );
+      expect(container.textContent).not.toContain('title-test');
+      expect(container.textContent).toContain('content_msg_not_tab');
+    } finally {
+      setBlockSpy.mockRestore();
+    }
+  });
+
   test('ブロック読み込み失敗時もエラー表示は機能する', async (): Promise<void> => {
     getAllBlockSpy.mockRejectedValue(new Error('load failed'));
 

--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -8,9 +8,8 @@ import Main from './main';
 import SideBar from './sideBar';
 
 const App: React.FC = () => {
-  // ロード完了までMainをマウントしない（nullはロード中を表す）。
-  // Mainはpropsを初期値としてstateに取り込むため、常にロード済みの
-  // データでマウントされる必要がある
+  // chrome.storageを単一の情報源とし、その読み込み結果をAppが所有する。
+  // Main/Blockはpropsの表示に徹する（nullはロード中を表す）
   const [blocks, setBlocks] = useState<model.Block[] | null>(null);
 
   useEffect(() => {
@@ -21,6 +20,31 @@ const App: React.FC = () => {
         chromeService.errorLog.set(error).catch(console.error);
       });
   }, []);
+
+  // ブロックの変更をstorageへ永続化し、成功時のみstateへ反映する。
+  // タブが空になったブロックはstorage側で削除されるため一覧からも除く
+  const updateBlock = (newBlock: model.Block) => {
+    chromeService.storage
+      .setBlock(newBlock)
+      .then(() => {
+        setBlocks((prevBlocks) => {
+          if (prevBlocks == null) {
+            return prevBlocks;
+          }
+          if (newBlock.tabs.length <= 0) {
+            return prevBlocks.filter(
+              (block) => block.indexNum != newBlock.indexNum,
+            );
+          }
+          return prevBlocks.map((block) =>
+            block.indexNum == newBlock.indexNum ? newBlock : block,
+          );
+        });
+      })
+      .catch((error) => {
+        chromeService.errorLog.set(error).catch(console.error);
+      });
+  };
 
   return (
     <div className="uk-container">
@@ -43,7 +67,11 @@ const App: React.FC = () => {
               アンマウントされないよう境界で隔離する（旧・独立ルート構成が
               持っていたフォールトアイソレーションの維持） */}
           <ErrorBoundary>
-            {blocks != null && <Main Block={blocks} />}
+            {/* ロード中に「保存済みタブなし」を誤表示しないよう
+                ロード完了までMainをマウントしない */}
+            {blocks != null && (
+              <Main blocks={blocks} updateBlock={updateBlock} />
+            )}
           </ErrorBoundary>
         </div>
         <SideBar />

--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -46,6 +46,13 @@ const App: React.FC = () => {
       });
   };
 
+  // 全データ削除をstorageへ反映し、成功時のみ一覧を空にする。
+  // 完了通知（alert）はUIを持つSideBar側で行うためPromiseを返す
+  const deleteAllBlocks = (): Promise<void> =>
+    chromeService.storage.allClear().then(() => {
+      setBlocks([]);
+    });
+
   return (
     <div className="uk-container">
       <div className="uk-grid">
@@ -74,7 +81,7 @@ const App: React.FC = () => {
             )}
           </ErrorBoundary>
         </div>
-        <SideBar />
+        <SideBar deleteAllBlocks={deleteAllBlocks} />
       </div>
     </div>
   );

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -1,50 +1,37 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { model } from '../types/interface';
 import { chromeService } from '../chromeService';
 import { Tab } from './tab';
 
 interface BlockProps {
-  Block: model.Block;
-  deleteBlock: VoidFunction;
+  block: model.Block;
+  // storageへの永続化とブロック一覧stateの更新はApp側で行う
+  updateBlock: (newBlock: model.Block) => void;
 }
 
+// ブロックのstateはAppが所有し、Blockはpropsの表示と操作イベントの発火に徹する
 const Block: React.FC<BlockProps> = (props) => {
-  const [nowBlock, setNowBlock] = useState(props.Block);
-  const createdAt = nowBlock.createdAt;
+  const block = props.block;
+  const createdAt = block.createdAt;
+
   const openLink = (index: number) => {
-    const url = nowBlock.tabs[index]!.url;
+    const url = block.tabs[index]!.url;
     chrome.tabs.create({ url: url, active: false }, function () {
       deleteClick(index);
     });
   };
 
-  const changeBlock = (newBlock: model.Block) => {
-    chromeService.storage
-      .setBlock(newBlock)
-      .then(() => {
-        setNowBlock(newBlock);
-        if (newBlock.tabs.length <= 0) {
-          props.deleteBlock();
-        }
-      })
-      .catch((error) => {
-        chromeService.errorLog.set(error).catch(console.error);
-      });
-  };
-
   const deleteClick = (index: number) => {
-    nowBlock.tabs.splice(index, 1);
-    const newBlock = {
-      tabs: nowBlock.tabs,
-      indexNum: nowBlock.indexNum,
-      createdAt: nowBlock.createdAt,
-    };
-    changeBlock(newBlock);
+    props.updateBlock({
+      tabs: block.tabs.filter((_, i) => i != index),
+      indexNum: block.indexNum,
+      createdAt: block.createdAt,
+    });
   };
 
   const openAllTab = () => {
     const promiseArray: Promise<void>[] = [];
-    for (const tab of nowBlock.tabs) {
+    for (const tab of block.tabs) {
       promiseArray.push(
         chromeService.tab.createTabs({ url: tab.url, active: false }),
       );
@@ -59,12 +46,11 @@ const Block: React.FC<BlockProps> = (props) => {
   };
 
   const deleteBlock = () => {
-    const newBlock = {
+    props.updateBlock({
       tabs: [],
-      indexNum: nowBlock.indexNum,
-      createdAt: nowBlock.createdAt,
-    };
-    changeBlock(newBlock);
+      indexNum: block.indexNum,
+      createdAt: block.createdAt,
+    });
   };
 
   return (
@@ -72,7 +58,7 @@ const Block: React.FC<BlockProps> = (props) => {
       <div className="uk-card-header">
         <h3 className="uk-card-title uk-margin-remove-bottom">
           {chrome.i18n.getMessage('content_msg_tab_length', [
-            nowBlock.tabs.length,
+            block.tabs.length,
           ])}
         </h3>
         <p className="uk-text-meta uk-margin-remove-top">
@@ -97,7 +83,7 @@ const Block: React.FC<BlockProps> = (props) => {
       </div>
       <div className="uk-card-body">
         <ul>
-          {nowBlock.tabs.map((tab, index) => {
+          {block.tabs.map((tab, index) => {
             return (
               <Tab
                 tab={tab}

--- a/src/js/components/main.tsx
+++ b/src/js/components/main.tsx
@@ -1,29 +1,23 @@
 import { model } from '../types/interface';
-import React, { useState } from 'react';
+import React from 'react';
 import Block from './block';
 
 interface MainProps {
-  Block: model.Block[];
+  blocks: model.Block[];
+  updateBlock: (newBlock: model.Block) => void;
 }
 
+// ブロック一覧のstateはAppが所有し、Mainはpropsの表示に徹する
 const Main: React.FC<MainProps> = (props) => {
-  const [nowBlocks, setNowBlocks] = useState(props.Block);
-
-  const deleteBlock = (index: number) => {
-    setNowBlocks((blocks) => {
-      return blocks.filter((block) => block.indexNum != index);
-    });
-  };
-
-  if (nowBlocks.length > 0) {
+  if (props.blocks.length > 0) {
     return (
       <div>
-        {nowBlocks.map((block) => {
+        {props.blocks.map((block) => {
           return (
             <Block
               key={block.indexNum}
-              Block={block}
-              deleteBlock={() => deleteBlock(block.indexNum)}
+              block={block}
+              updateBlock={props.updateBlock}
             />
           );
         })}

--- a/src/js/components/sideBar.tsx
+++ b/src/js/components/sideBar.tsx
@@ -2,7 +2,12 @@ import React, { useRef, useState } from 'react';
 import { blockService } from '../blockService';
 import { chromeService } from '../chromeService';
 
-const SideBar: React.FC = () => {
+interface SideBarProps {
+  // storageの全削除とブロック一覧stateの更新はApp側で行う
+  deleteAllBlocks: () => Promise<void>;
+}
+
+const SideBar: React.FC<SideBarProps> = (props) => {
   const [exportText, setExportText] = useState('');
   const importRef = useRef<HTMLTextAreaElement>(null);
 
@@ -31,8 +36,8 @@ const SideBar: React.FC = () => {
     if (
       window.confirm(chrome.i18n.getMessage('content_msg_all_delete_confirm'))
     ) {
-      chromeService.storage
-        .allClear()
+      props
+        .deleteAllBlocks()
         .then(() =>
           alert(chrome.i18n.getMessage('content_msg_all_delete_finish')),
         )


### PR DESCRIPTION
closes #177

## 概要
`main.tsx` / `block.tsx` が props を `useState` の初期値へコピーするパターン（`useState(props.Block)`）になっており、chrome.storage・親 state・子 state に情報が三重化していた問題を解消します。ブロック一覧の state を App に持ち上げ、Main / Block は props の表示に徹する構造へリファクタリングしました。振る舞いは現状維持で、状態管理の構造のみを変更しています。

## 設計

### state の所有者
- **App（app.tsx）** がブロック一覧の state（`blocks`）を唯一所有
- chrome.storage を単一の情報源とし、更新は App の `updateBlock` に集約
  - `setBlock` で永続化が成功した場合のみ state へ反映（タブが空になったブロックは storage 側で削除されるため一覧からも除外）
- Main / Block は state を持たないプレゼンテーション寄りのコンポーネントに変更

### データフロー Before / After

**Before**
```
chrome.storage → App(blocks) → Main: useState(props.Block) → Block: useState(props.Block)
削除: Block が storage 更新 + 自身の state 更新 → deleteBlock コールバックで Main の state も更新（バケツリレー）
```

**After**
```
chrome.storage → App(blocks) → Main(props) → Block(props)
削除・全開き: Block → props.updateBlock(newBlock) → App が storage 永続化 → 成功時に App の state を更新 → props 経由で再描画
```

### 変更点
- `app.tsx`: `updateBlock`（永続化 + state 更新）を追加し Main へ渡す
- `main.tsx`: `useState` を廃止し、`blocks` / `updateBlock` の props 表示に徹する
- `block.tsx`: `useState` を廃止。`deleteClick` は `splice` による props 破壊をやめ `filter` で新配列を生成し、更新はすべて `props.updateBlock` に委譲
- `sideBar.tsx` / `app.tsx`: 全データ削除も同方針に統一。storage の `allClear` と state 更新を App の `deleteAllBlocks` に集約し、成功時に一覧を空表示へ切り替える（SideBar は confirm / alert の UI に徹する）
- `app.test.tsx`: 削除操作・全データ削除で App の state が更新され一覧から消えることを検証するテストを追加

### スコープ外
- `chrome.storage.onChanged` の購読などの発展形（issue の方針どおり今回は対象外）

## テスト
- `npm test`: 45 passed
- `npm run lint`: エラーなし
- `npm run build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
