### PR TITLE
storage.syncの使用量をtabsページに表示する

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -51,5 +51,22 @@
   },
   "content_msg_open_tab_page": {
     "message": "Open Saved tabs Page"
+  },
+  "content_msg_storage_usage": {
+    "message": "Storage Usage"
+  },
+  "content_msg_storage_usage_detail": {
+    "message": "$used$ / $total$ bytes ($percentage$% used)",
+    "placeholders": {
+      "used": {
+        "content": "$1"
+      },
+      "total": {
+        "content": "$2"
+      },
+      "percentage": {
+        "content": "$3"
+      }
+    }
   }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -51,5 +51,22 @@
   },
   "content_msg_open_tab_page": {
     "message": "保存済みタブのページを開く"
+  },
+  "content_msg_storage_usage": {
+    "message": "ストレージ使用量"
+  },
+  "content_msg_storage_usage_detail": {
+    "message": "$used$ / $total$ バイト（使用率 $percentage$%）",
+    "placeholders": {
+      "used": {
+        "content": "$1"
+      },
+      "total": {
+        "content": "$2"
+      },
+      "percentage": {
+        "content": "$3"
+      }
+    }
   }
 }

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -77,6 +77,10 @@ describe('App', (): void => {
             cb();
           },
         },
+        sync: {
+          QUOTA_BYTES: 102400,
+          getBytesInUse: (): Promise<number> => Promise.resolve(0),
+        },
         onChanged: {
           addListener: (
             listener: (

--- a/src/js/components/sideBar.tsx
+++ b/src/js/components/sideBar.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { blockService } from '../blockService';
 import { chromeService } from '../chromeService';
+import StorageUsage from './storageUsage';
 
 interface SideBarProps {
   // storageの全削除とブロック一覧stateの更新はApp側で行う
@@ -113,6 +114,7 @@ const SideBar: React.FC<SideBarProps> = (props) => {
           </li>
         </ul>
       </div>
+      <StorageUsage />
     </aside>
   );
 };

--- a/src/js/components/storageUsage.test.tsx
+++ b/src/js/components/storageUsage.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import StorageUsage from './storageUsage';
+
+// テスティングライブラリを介さず素のactを使うため必要
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('StorageUsage', (): void => {
+  let bytesInUse: number;
+  let onChangedListeners: Array<
+    (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string,
+    ) => void
+  >;
+  let container: HTMLDivElement;
+  let root: Root;
+  const removeListener = jest.fn();
+
+  const mount = async (): Promise<void> => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<StorageUsage />);
+    });
+  };
+
+  const notifyChanged = async (areaName: string): Promise<void> => {
+    await act(async () => {
+      for (const listener of onChangedListeners) {
+        listener({ td_0: { newValue: 'dummy' } }, areaName);
+      }
+    });
+  };
+
+  beforeEach((): void => {
+    bytesInUse = 1024;
+    onChangedListeners = [];
+    removeListener.mockClear();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      i18n: {
+        // 引数の確認ができるよう、キーと置換引数を連結して返す
+        getMessage: (key: string, substitutions?: string[]): string =>
+          substitutions == null ? key : `${key}:${substitutions.join('/')}`,
+      },
+      storage: {
+        sync: {
+          QUOTA_BYTES: 102400,
+          getBytesInUse: (): Promise<number> => Promise.resolve(bytesInUse),
+        },
+        onChanged: {
+          addListener: (
+            listener: (
+              changes: { [key: string]: chrome.storage.StorageChange },
+              areaName: string,
+            ) => void,
+          ): void => {
+            onChangedListeners.push(listener);
+          },
+          removeListener: removeListener,
+        },
+      },
+    };
+  });
+
+  afterEach((): void => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  test('マウント時に使用量と上限とプログレスバーを表示する', async (): Promise<void> => {
+    await mount();
+
+    expect(container.textContent).toContain('content_msg_storage_usage');
+    expect(container.textContent).toContain(
+      `content_msg_storage_usage_detail:${(1024).toLocaleString()}/${(102400).toLocaleString()}/1.00`,
+    );
+    const progress = container.querySelector<HTMLProgressElement>(
+      'progress.uk-progress',
+    )!;
+    expect(progress.value).toBe(1024);
+    expect(progress.max).toBe(102400);
+  });
+
+  test('storage.syncの変更で使用量を再取得して表示を更新する', async (): Promise<void> => {
+    await mount();
+
+    bytesInUse = 51200;
+    await notifyChanged('sync');
+
+    expect(container.textContent).toContain(
+      `content_msg_storage_usage_detail:${(51200).toLocaleString()}/${(102400).toLocaleString()}/50.00`,
+    );
+    const progress = container.querySelector<HTMLProgressElement>(
+      'progress.uk-progress',
+    )!;
+    expect(progress.value).toBe(51200);
+  });
+
+  test('storage.local の変更では再取得しない', async (): Promise<void> => {
+    await mount();
+
+    bytesInUse = 51200;
+    await notifyChanged('local');
+
+    expect(container.textContent).toContain(
+      `content_msg_storage_usage_detail:${(1024).toLocaleString()}/${(102400).toLocaleString()}/1.00`,
+    );
+  });
+
+  test('アンマウント時にonChangedのリスナーを解除する', async (): Promise<void> => {
+    await mount();
+
+    act(() => root.unmount());
+
+    expect(removeListener).toHaveBeenCalledWith(onChangedListeners[0]);
+  });
+});

--- a/src/js/components/storageUsage.tsx
+++ b/src/js/components/storageUsage.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+
+const StorageUsage: React.FC = () => {
+  // 取得完了まで表示しない（nullはロード中を表す）
+  const [bytesInUse, setBytesInUse] = useState<number | null>(null);
+  const totalBytes = chrome.storage.sync.QUOTA_BYTES;
+
+  useEffect(() => {
+    const updateBytesInUse = () => {
+      chrome.storage.sync
+        .getBytesInUse()
+        .then(setBytesInUse)
+        .catch(console.error);
+    };
+    updateBytesInUse();
+
+    // タブの保存・削除・インポートなどの操作後に使用量を追随させるため
+    // storage.syncの変更を監視して再取得する
+    const onChanged = (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string,
+    ) => {
+      if (areaName === 'sync') {
+        updateBytesInUse();
+      }
+    };
+    chrome.storage.onChanged.addListener(onChanged);
+    return () => chrome.storage.onChanged.removeListener(onChanged);
+  }, []);
+
+  if (bytesInUse == null) {
+    return null;
+  }
+
+  const percentage = ((bytesInUse / totalBytes) * 100).toFixed(2);
+
+  return (
+    <div className="uk-card uk-card-default uk-card-body uk-margin-top storage-usage">
+      <h4 className="uk-card-title uk-margin-remove-bottom">
+        {chrome.i18n.getMessage('content_msg_storage_usage')}
+      </h4>
+      <progress className="uk-progress" value={bytesInUse} max={totalBytes} />
+      <p className="uk-text-meta uk-margin-remove-top">
+        {chrome.i18n.getMessage('content_msg_storage_usage_detail', [
+          bytesInUse.toLocaleString(),
+          totalBytes.toLocaleString(),
+          percentage,
+        ])}
+      </p>
+    </div>
+  );
+};
+
+export default StorageUsage;


### PR DESCRIPTION
closes #163

## 概要

tabsページに `chrome.storage.sync` の使用量（使用バイト数 / 上限、使用率のプログレスバー）を表示する `StorageUsage` コンポーネントを追加しました。

## UI・表示位置

- サイドバー（メニューカードの下）に UIkit のカード（`uk-card`）として表示
  - タイトル（「ストレージ使用量」/「Storage Usage」）
  - `uk-progress` のプログレスバー（value=使用バイト数, max=`QUOTA_BYTES`）
  - 「1,024 / 102,400 バイト（使用率 1.00%）」形式の詳細テキスト
- **表示位置の判断理由**: ストレージ使用量は保存データ全体に関するメタ情報であり、エクスポート・インポート・全削除といった全体操作を集めたサイドバーに置くのが自然と判断しました。ブロック一覧の上に置くと本来の主役であるタブ一覧が下に押し下げられるため避けています。

## 実装内容

- `src/js/components/storageUsage.tsx`: `chrome.storage.sync.getBytesInUse()` と `chrome.storage.sync.QUOTA_BYTES` で使用量を取得。取得完了までは何も表示しない（既存Appのロード中表現に合わせてnullを使用）
- タブの保存・削除・インポート等の操作後に追随できるよう `chrome.storage.onChanged` を監視し、`areaName === 'sync'` の変更時のみ再取得。アンマウント時にリスナーを解除
- i18nキーを追加（`content_msg_storage_usage`, `content_msg_storage_usage_detail`。後者はプレースホルダー付きで en/ja 両対応）
- テスト: `storageUsage.test.tsx` を error.test.tsx 等の既存パターン（素のact + createRoot + chromeモック）に合わせて追加。初期表示・sync変更時の更新・local変更時の非更新・リスナー解除を検証。app.test.tsx のchromeモックに `storage.sync` を追加

## テスト

- `npm test`: 7 suites / 46 tests すべてpass
- `npm run lint`: pass
- `npm run build`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)