### PR TITLE
v0.4.1 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.4.1 (2026-08-04)
+
+- [FIX] タブページの title の typo を修正 (syncTabCliper → SyncTabClipper) (#185)
+- [FIX] タブの URL・タイトルが二重に HTML エスケープされて表示される問題を修正 (#186)
+- [FIX] タブカードに未評価のテンプレートリテラルが data-created-at 属性として残っていたのを削除 (#187)
+- [DEV] html-webpack-plugin を導入し、tabs.html への script タグを自動注入に変更 (#189)
+
 # v0.4.0 (2026-08-03)
 
 - [DEV] タブページの描画を単一 React ルートに統合し、サイドバーの生 DOM 操作を React の state/ref に置き換え (#173, #174)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SyncTabClipper",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "manifest_version": 3,
   "description": "__MSG_Description__",
   "default_locale": "en",


### PR DESCRIPTION
## 概要

v0.4.0 → master の差分を v0.4.1 としてリリースする準備です。

- `src/manifest.json` の version を 0.4.1 に更新
- CHANGELOG に v0.4.1 (2026-08-04) を追記

## v0.4.1 に含まれる変更

- [FIX] タブページの title の typo を修正 (syncTabCliper → SyncTabClipper) (#185)
- [FIX] タブの URL・タイトルが二重に HTML エスケープされて表示される問題を修正 (#176 / #186)
- [FIX] タブカードに未評価のテンプレートリテラルが data-created-at 属性として残っていたのを削除 (#175 / #187)
- [DEV] html-webpack-plugin を導入し、tabs.html への script タグを自動注入に変更 (#189)

🤖 Generated with [Claude Code](https://claude.com/claude-code)