### PR TITLE
CHANGELOG の v0.4.1 にストア説明文更新 (#203) を追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [FIX] タブの URL・タイトルが二重に HTML エスケープされて表示される問題を修正 (#186)
 - [FIX] タブカードに未評価のテンプレートリテラルが data-created-at 属性として残っていたのを削除 (#187)
 - [DEV] html-webpack-plugin を導入し、tabs.html への script タグを自動注入に変更 (#189)
+- [UPDATE] ストア掲載の短い説明文 (manifest description) を日英とも刷新 (#203)
 
 # v0.4.0 (2026-08-03)
 


### PR DESCRIPTION
## 概要

v0.4.1 リリース準備 (#199) のマージ後に、ストア掲載の短い説明文の更新 (#203) が master に入りました。
この変更は v0.4.1 のパッケージに含まれるため、CHANGELOG の v0.4.1 エントリに追記します。

## 変更内容

- CHANGELOG.md の v0.4.1 に以下を追加
  - `[UPDATE] ストア掲載の短い説明文 (manifest description) を日英とも刷新 (#203)`

## 関連

- リリース PR: #199
- 説明文更新 PR: #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)