### PR TITLE
TypeScript を 6.0.3 に更新（TS7 は ts-jest 未対応のため見送り）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,10 @@
         "react-dom": "^19.2.8"
       },
       "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.5",
         "@types/chrome": "^0.2.5",
         "@types/jest": "^30.0.0",
+        "@types/node": "^26.1.2",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@types/uikit": "^3.23.0",
@@ -31,7 +32,7 @@
         "terser-webpack-plugin": "^5.6.1",
         "ts-jest": "^29.4.12",
         "ts-loader": "^9.6.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.65.0",
         "uikit": "^3.25.20",
         "webpack": "^5.51.1",
@@ -882,24 +883,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1874,10 +1867,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.1.tgz",
-      "integrity": "sha512-UW7cbLqf/Wu5XH2RKKY1cHwUNLicIDRLMraYKz+HHAerJ0ZffUEk+fMnd8qU2JaS6cAy0r8tsaf7yqHASf/Y0Q==",
-      "dev": true
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.18",
@@ -4487,19 +4484,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
@@ -9434,9 +9418,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -9704,6 +9688,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "SyncTabClipper",
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.5",
     "@types/chrome": "^0.2.5",
     "@types/jest": "^30.0.0",
+    "@types/node": "^26.1.2",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@types/uikit": "^3.23.0",
@@ -22,7 +23,7 @@
     "terser-webpack-plugin": "^5.6.1",
     "ts-jest": "^29.4.12",
     "ts-loader": "^9.6.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0",
     "uikit": "^3.25.20",
     "webpack": "^5.51.1",

--- a/src/js/types/css.d.ts
+++ b/src/js/types/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,15 @@
 {
   "compilerOptions": {
     "target": "ES2019",
-    "module": "ES2015",
+    "module": "ESNext",
     "sourceMap": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": "./",
-    "paths": {
-      "interface": ["types/interface"]
-    },
-    "typeRoots": ["node_modules/@types", "types"],
+    "types": ["chrome", "jest", "node"],
     "jsx": "react-jsx"
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
## 概要

Dependabot の #201（TypeScript 7.0.2）は ts-jest の peerDependency（`typescript >=4.3 <7`）と競合してマージ不可のため、現時点でアップデート可能な最新バージョンである **TypeScript 6.0.3** への更新 PR を作成した。

## 変更内容

### typescript ^5.9.3 → ^6.0.3

- 7.0.2 を見送った理由: `ts-jest@29.4.12` の peerDependency が `<7` のため `npm ci` が ERESOLVE で失敗する（#201 の CI 失敗と同じ原因）
- typescript-eslint の peerDependency は `<6.1.0` のため 6.0.x が上限

### @eslint/js ^10.0.1 → ^9.39.5（巻き戻し）

#202 でマージした @eslint/js 10 は optional peerDependency に `eslint ^10` を持ち、eslint 9 環境では依存を再解決する `npm install` が ERESOLVE で失敗する（lockfile をそのまま使う `npm ci` は通るため CI では検出されなかった）。eslint 10 へは eslint-plugin-react の peerDependency 制約（`^9.7` まで）により上げられないため、eslint 本体と揃えて 9 系へ戻す。

### TS6 の破壊的変更への対応

- `moduleResolution: node`（node10）と `baseUrl` が deprecated エラーになるため、`moduleResolution: bundler` + `module: ESNext` へ移行
- `paths`（`interface` エイリアス）と `typeRoots` は未使用だったため削除（import はすべて相対パスで、`types/` ディレクトリも存在しない）
- `@types` パッケージの自動読み込みが廃止されたため `types: ["chrome", "jest", "node"]` を明示し、これまで推移的依存として読み込まれていた `@types/node` を devDependencies に追加
- CSS の side-effect import が TS2882 エラーになるため `src/js/types/css.d.ts`（`declare module '*.css'`）を追加

## 動作確認

CI と同じ手順をローカルで実行しすべて成功:

- `npx tsc --noEmit` ✅
- `npm run format:check` ✅
- `npm run lint` ✅
- `npm test` ✅（7 suites / 43 tests すべてパス）
- `npm run build:prod` ✅

## 補足

- eslint 10（#200）は eslint-plugin-react の対応待ちのため、今回アップデート可能なバージョンはなし（9.x の最新 9.39.5 を使用中）
- #201 は本 PR マージ後も TS7 用としてオープンのまま残る（`@dependabot ignore this major version` でクローズも可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)