### PR TITLE
v0.4.2 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.4.2 (2026-08-04)
+
+- [FIX] 全データ削除後も一覧にブロックが表示されたままになる問題を修正 (#188)
+- [DEV] ブロック一覧の state を App に持ち上げ、Main/Block の props→useState コピーを廃止 (#188)
+- [DEV] TypeScript を 6.0.3 に更新し、TS6 の deprecation に対応 (#206)
+- [DEV] @eslint/js を 10.0.1 に更新 (#202)
+
 # v0.4.1 (2026-08-04)
 
 - [FIX] タブページの title の typo を修正 (syncTabCliper → SyncTabClipper) (#185)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 - [FIX] 全データ削除後も一覧にブロックが表示されたままになる問題を修正 (#188)
 - [DEV] ブロック一覧の state を App に持ち上げ、Main/Block の props→useState コピーを廃止 (#188)
 - [DEV] TypeScript を 6.0.3 に更新し、TS6 の deprecation に対応 (#206)
-- [DEV] @eslint/js を 10.0.1 に更新 (#202)
 
 # v0.4.1 (2026-08-04)
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SyncTabClipper",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "manifest_version": 3,
   "description": "__MSG_Description__",
   "default_locale": "en",


### PR DESCRIPTION
## 概要

パッチバージョンアップ (v0.4.1 → v0.4.2) のリリース準備です。

- `src/manifest.json` の version を 0.4.2 に更新
- CHANGELOG に v0.4.2 のエントリを追加

## v0.4.2 に含まれる変更

- [FIX] 全データ削除後も一覧にブロックが表示されたままになる問題を修正 (#188)
- [DEV] ブロック一覧の state を App に持ち上げ、Main/Block の props→useState コピーを廃止 (#188)
- [DEV] TypeScript を 6.0.3 に更新し、TS6 の deprecation に対応 (#206)
- [DEV] @eslint/js を 10.0.1 に更新 (#202)

🤖 Generated with [Claude Code](https://claude.com/claude-code)