### PR TITLE
Tab一覧のkeyに配列indexを使わずURLベースの安定keyにする

### DIFF
--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -89,7 +89,7 @@ const Block: React.FC<BlockProps> = (props) => {
                 tab={tab}
                 deleteClick={() => deleteClick(index)}
                 openLinkClick={() => openLink(index)}
-                key={index}
+                key={`${tab.url}-${index}`}
               />
             );
           })}


### PR DESCRIPTION
## 概要

issue #211 の対応。`src/js/components/block.tsx` の Tab リストレンダリングで `key={index}` を使用していたのを、`key={`${tab.url}-${index}`}` の URL ベースの複合 key に変更しました。

同一 URL のタブが複数保存されうるため、issue の修正方針どおり index との複合 key としています。

## 受け入れ条件

- [x] `block.tsx` の Tab リストの key が配列 index 単体ではなくなっている
- [x] `npm test` が通る（8 suites / 49 tests passed）
- [x] `npm run lint` が通る

Fixes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)