### PR TITLE
Blockの再レンダリング最適化（useCallback + React.memo）

### DIFF
--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -164,6 +164,57 @@ describe('App', (): void => {
     }
   });
 
+  test('あるブロックの更新時に他のブロックは再レンダリングされない', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([
+      {
+        indexNum: 0,
+        createdAt: new Date('2021-01-02T03:04:05.678Z'),
+        tabs: [
+          { url: 'https://example.com/a1', title: 'title-a1' },
+          { url: 'https://example.com/a2', title: 'title-a2' },
+        ],
+      },
+      {
+        indexNum: 1,
+        createdAt: new Date('2021-01-03T03:04:05.678Z'),
+        tabs: [{ url: 'https://example.com/b1', title: 'title-b1' }],
+      },
+    ]);
+    const setBlockSpy = jest
+      .spyOn(chromeService.storage, 'setBlock')
+      .mockResolvedValue(undefined);
+    // Blockはレンダリングのたびにcontent_msg_tab_lengthを必ず1回取得するため、
+    // その呼び出し回数を再レンダリング回数の代理指標として使う
+    const getMessageSpy = jest.fn((key: string): string => key);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome.i18n.getMessage = getMessageSpy;
+
+    try {
+      await mount();
+      getMessageSpy.mockClear();
+
+      // 先頭ブロック（ブロックA）のタブを1件削除する
+      const tabCloseLink = container.querySelector(
+        '.tab_close',
+      ) as HTMLElement;
+      await act(async () => {
+        tabCloseLink.click();
+      });
+
+      expect(container.textContent).not.toContain('title-a1');
+      expect(container.textContent).toContain('title-a2');
+      expect(container.textContent).toContain('title-b1');
+      // 再レンダリングされたのは更新したブロックAのみ
+      // （ブロックBも再レンダリングされると2になる）
+      const blockRenderCount = getMessageSpy.mock.calls.filter(
+        ([key]) => key === 'content_msg_tab_length',
+      ).length;
+      expect(blockRenderCount).toBe(1);
+    } finally {
+      setBlockSpy.mockRestore();
+    }
+  });
+
   test('全データ削除時はAppのstateが空になり未保存メッセージを表示する', async (): Promise<void> => {
     getAllBlockSpy.mockResolvedValue([
       {

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -194,9 +194,7 @@ describe('App', (): void => {
       getMessageSpy.mockClear();
 
       // 先頭ブロック（ブロックA）のタブを1件削除する
-      const tabCloseLink = container.querySelector(
-        '.tab_close',
-      ) as HTMLElement;
+      const tabCloseLink = container.querySelector('.tab_close') as HTMLElement;
       await act(async () => {
         tabCloseLink.click();
       });

--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { model } from '../types/interface';
 import { chromeService } from '../chromeService';
 import Header from './header';
@@ -22,8 +22,9 @@ const App: React.FC = () => {
   }, []);
 
   // ブロックの変更をstorageへ永続化し、成功時のみstateへ反映する。
-  // タブが空になったブロックはstorage側で削除されるため一覧からも除く
-  const updateBlock = (newBlock: model.Block) => {
+  // タブが空になったブロックはstorage側で削除されるため一覧からも除く。
+  // React.memo化したBlockの再レンダリングを防ぐため参照を安定させる
+  const updateBlock = useCallback((newBlock: model.Block) => {
     chromeService.storage
       .setBlock(newBlock)
       .then(() => {
@@ -44,14 +45,17 @@ const App: React.FC = () => {
       .catch((error) => {
         chromeService.errorLog.set(error).catch(console.error);
       });
-  };
+  }, []);
 
   // 全データ削除をstorageへ反映し、成功時のみ一覧を空にする。
   // 完了通知（alert）はUIを持つSideBar側で行うためPromiseを返す
-  const deleteAllBlocks = (): Promise<void> =>
-    chromeService.storage.allClear().then(() => {
-      setBlocks([]);
-    });
+  const deleteAllBlocks = useCallback(
+    (): Promise<void> =>
+      chromeService.storage.allClear().then(() => {
+        setBlocks([]);
+      }),
+    [],
+  );
 
   return (
     <div className="uk-container">

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -9,8 +9,10 @@ interface BlockProps {
   updateBlock: (newBlock: model.Block) => void;
 }
 
-// ブロックのstateはAppが所有し、Blockはpropsの表示と操作イベントの発火に徹する
-const Block: React.FC<BlockProps> = (props) => {
+// ブロックのstateはAppが所有し、Blockはpropsの表示と操作イベントの発火に徹する。
+// memo化により、他ブロック更新時の再レンダリングを避ける
+// （updateBlockはApp側でuseCallbackにより参照が安定している前提）
+const Block: React.FC<BlockProps> = React.memo((props) => {
   const block = props.block;
   const createdAt = block.createdAt;
 
@@ -97,6 +99,8 @@ const Block: React.FC<BlockProps> = (props) => {
       </div>
     </div>
   );
-};
+});
+
+Block.displayName = 'Block';
 
 export default Block;


### PR DESCRIPTION
## 概要

fixes #212

`app.tsx` の `updateBlock` が毎レンダーで再生成され `Main` → 全 `Block` に渡っていたため、1ブロックの更新で全ブロックが再レンダリングされていた問題を修正します。

## 変更内容

- `app.tsx`: `updateBlock` / `deleteAllBlocks` を `useCallback`（依存配列は空。setState は functional update のため）でラップ
- `block.tsx`: `Block` を `React.memo` でラップ（`displayName` も設定）
- `app.test.tsx`: ブロックA更新時にブロックBが再レンダリングされないことを、`Block` レンダリングごとに必ず呼ばれる `chrome.i18n.getMessage('content_msg_tab_length')` の呼び出し回数で検証するテストを追加

## 受け入れ条件の確認

- [x] ブロックAの更新時にブロックBの `Block` コンポーネントが再レンダリングされない（テストで確認）
- [x] タブ削除・全タブ開く・全削除の既存動作が変わらない（既存テストがすべてパス）
- [x] `npm test`（50 passed）/ `npm run lint` / `npm run build` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)