### PR TITLE
Block.openLinkをchromeService.tab.createTabs経由に変更しエラー通知を追加

### DIFF
--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -18,9 +18,12 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
 
   const openLink = (index: number) => {
     const url = block.tabs[index]!.url;
-    chrome.tabs.create({ url: url, active: false }, function () {
-      deleteClick(index);
-    });
+    chromeService.tab
+      .createTabs({ url: url, active: false })
+      .then(() => deleteClick(index))
+      .catch((error) => {
+        chromeService.errorLog.set(error).catch(console.error);
+      });
   };
 
   const deleteClick = (index: number) => {


### PR DESCRIPTION
## 概要

Fixes #216

`Block.openLink()` が生の `chrome.tabs.create` を使用しており、タブ作成失敗時にエラー通知されず、コールバックで `deleteClick` が無条件実行されるため開けなかったタブが一覧から削除される恐れがあった。

## 変更内容

- `openLink` を `chromeService.tab.createTabs()` 経由に変更（`openAllTab` と同じ設計に統一）
- 失敗時は `chromeService.errorLog.set()` でエラー通知し、`deleteClick` を呼ばない（タブを一覧に残す）

## 確認

- [x] `npm test`（50件パス）
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)