### PR TITLE
条件レンダリングを && ではなく三項演算子に統一する

### DIFF
--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -80,9 +80,9 @@ const App: React.FC = () => {
           <ErrorBoundary>
             {/* ロード中に「保存済みタブなし」を誤表示しないよう
                 ロード完了までMainをマウントしない */}
-            {blocks != null && (
+            {blocks != null ? (
               <Main blocks={blocks} updateBlock={updateBlock} />
-            )}
+            ) : null}
           </ErrorBoundary>
         </div>
         <SideBar deleteAllBlocks={deleteAllBlocks} />


### PR DESCRIPTION
## 概要

issue #213 の対応。`src/js/components/app.tsx` の JSX 内 `&&` 条件レンダリングを三項演算子に変更しました。

## 変更内容

- `{blocks != null && (...)}` → `{blocks != null ? (...) : null}`

`src/js/components/` 配下を grep で確認し、JSX 内の `&&` 条件レンダリングはこの1箇所のみでした（`error.tsx` の `&&` はロジック内の条件式のため対象外）。

## 確認

- [x] `npm test`（50件 pass）
- [x] `npm run lint`
- [x] prettier チェック

closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)