### PR TITLE
chromeServiceのコールバック→Promise手動ラップをMV3のPromise APIで簡素化

### DIFF
--- a/src/js/chromeService.test.ts
+++ b/src/js/chromeService.test.ts
@@ -14,14 +14,11 @@ describe('chromeService.errorLog', (): void => {
       runtime: {},
       storage: {
         local: {
-          set: (obj: { [key: string]: string }, cb: () => void): void => {
+          set: (obj: { [key: string]: string }): Promise<void> => {
             Object.assign(localData, obj);
-            cb();
+            return Promise.resolve();
           },
-          get: (
-            keys: string[],
-            cb: (items: { [key: string]: string }) => void,
-          ): void => {
+          get: (keys: string[]): Promise<{ [key: string]: string }> => {
             const res: { [key: string]: string } = {};
             for (const key of keys) {
               const value = localData[key];
@@ -29,11 +26,11 @@ describe('chromeService.errorLog', (): void => {
                 res[key] = value;
               }
             }
-            cb(res);
+            return Promise.resolve(res);
           },
-          remove: (key: string, cb: () => void): void => {
+          remove: (key: string): Promise<void> => {
             delete localData[key];
-            cb();
+            return Promise.resolve();
           },
         },
       },
@@ -71,22 +68,16 @@ describe('chromeService.errorLog', (): void => {
     await expect(chromeService.errorLog.get()).resolves.toBeNull();
   });
 
-  test('lastError発生時はErrorインスタンスでrejectする', async (): Promise<void> => {
+  test('storage失敗時はErrorインスタンスでrejectしバッジは立たない', async (): Promise<void> => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).chrome.storage.local.set = (
-      _obj: { [key: string]: string },
-      cb: () => void,
-    ): void => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (global as any).chrome.runtime.lastError = { message: 'quota exceeded' };
-      cb();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      delete (global as any).chrome.runtime.lastError;
+    (global as any).chrome.storage.local.set = (): Promise<void> => {
+      return Promise.reject(new Error('quota exceeded'));
     };
 
     const result = chromeService.errorLog.set('boom');
     await expect(result).rejects.toBeInstanceOf(Error);
     await expect(result).rejects.toThrow('quota exceeded');
+    expect(setBadgeText).not.toHaveBeenCalled();
   });
 
   test('clearで保存とバッジが消える', async (): Promise<void> => {

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -8,57 +8,22 @@ export namespace chromeService {
     const tabKey = (index: number): string => `td_${index}`;
 
     function deleteSyncStorage(key: string): Promise<void> {
-      return new Promise((resolve, reject) => {
-        chrome.storage.sync.remove(key, () => {
-          const error = chrome.runtime.lastError;
-          if (error) {
-            reject(new Error(error.message));
-          } else {
-            resolve();
-          }
-        });
-      });
+      return chrome.storage.sync.remove(key);
     }
 
     function setSyncStorage(key: string, value: string): Promise<void> {
       const setObj: { [key: string]: string } = {};
       setObj[key] = value;
-      return new Promise((resolve, reject) => {
-        chrome.storage.sync.set(setObj, () => {
-          const error = chrome.runtime.lastError;
-          if (error) {
-            reject(new Error(error.message));
-          } else {
-            resolve();
-          }
-        });
-      });
+      return chrome.storage.sync.set(setObj);
     }
 
-    function getSyncStorage(key: string): Promise<string> {
-      return new Promise((resolve, reject) => {
-        chrome.storage.sync.get([key], (item) => {
-          const error = chrome.runtime.lastError;
-          if (error) {
-            reject(new Error(error.message));
-          } else {
-            resolve(item[key] as string);
-          }
-        });
-      });
+    async function getSyncStorage(key: string): Promise<string> {
+      const item = await chrome.storage.sync.get([key]);
+      return item[key] as string;
     }
 
     export async function allClear(): Promise<void> {
-      return new Promise((resolve, reject) => {
-        chrome.storage.sync.clear(function () {
-          const error = chrome.runtime.lastError;
-          if (error) {
-            reject(new Error(error.message));
-          } else {
-            resolve();
-          }
-        });
-      });
+      return chrome.storage.sync.clear();
     }
 
     function getSyncStorageReturnIndex(
@@ -137,32 +102,14 @@ export namespace chromeService {
   }
 
   export namespace tab {
-    export function createTabs(
+    export async function createTabs(
       properties: chrome.tabs.CreateProperties,
     ): Promise<void> {
-      return new Promise((resolve, reject) => {
-        chrome.tabs.create(properties, () => {
-          const error = chrome.runtime.lastError;
-          if (error) {
-            reject(new Error(error.message));
-          } else {
-            resolve();
-          }
-        });
-      });
+      await chrome.tabs.create(properties);
     }
 
     async function closeTab(tab: chrome.tabs.Tab): Promise<void> {
-      return new Promise((resolve, reject) => {
-        chrome.tabs.remove(tab.id!, () => {
-          const error = chrome.runtime.lastError;
-          if (error) {
-            reject(new Error(error.message));
-          } else {
-            resolve();
-          }
-        });
-      });
+      return chrome.tabs.remove(tab.id!);
     }
 
     export async function closeTabs(tabs: chrome.tabs.Tab[]): Promise<void> {
@@ -183,16 +130,7 @@ export namespace chromeService {
     export function queryTabs(
       queryInfo: chrome.tabs.QueryInfo,
     ): Promise<chrome.tabs.Tab[]> {
-      return new Promise((resolve, reject) => {
-        chrome.tabs.query(queryInfo, (tabs) => {
-          const error = chrome.runtime.lastError;
-          if (error) {
-            reject(new Error(error.message));
-          } else {
-            resolve(tabs);
-          }
-        });
-      });
+      return chrome.tabs.query(queryInfo);
     }
 
     export async function createTabsPageTab(): Promise<void> {
@@ -225,57 +163,31 @@ export namespace chromeService {
      * @param {unknown} error 発生したエラー（Error以外はStringで文字列化）
      * @return {Promise<void>}
      */
-    export function set(error: unknown): Promise<void> {
+    export async function set(error: unknown): Promise<void> {
       const message = error instanceof Error ? error.message : String(error);
       const setObj: { [key: string]: string } = {};
       setObj[errorKey] = message;
-      return new Promise((resolve, reject) => {
-        chrome.storage.local.set(setObj, () => {
-          const lastError = chrome.runtime.lastError;
-          if (lastError) {
-            reject(new Error(lastError.message));
-          } else {
-            chrome.action.setBadgeBackgroundColor({ color: '#DD2222' });
-            chrome.action.setBadgeText({ text: '!' });
-            resolve();
-          }
-        });
-      });
+      await chrome.storage.local.set(setObj);
+      chrome.action.setBadgeBackgroundColor({ color: '#DD2222' });
+      chrome.action.setBadgeText({ text: '!' });
     }
 
     /**
      * 保存されたエラーメッセージとバッジをクリアする
      * @return {Promise<void>}
      */
-    export function clear(): Promise<void> {
-      return new Promise((resolve, reject) => {
-        chrome.storage.local.remove(errorKey, () => {
-          const error = chrome.runtime.lastError;
-          if (error) {
-            reject(new Error(error.message));
-          } else {
-            chrome.action.setBadgeText({ text: '' });
-            resolve();
-          }
-        });
-      });
+    export async function clear(): Promise<void> {
+      await chrome.storage.local.remove(errorKey);
+      chrome.action.setBadgeText({ text: '' });
     }
 
     /**
      * 保存されたエラーメッセージを取得する。保存とバッジはクリアしない
      * @return {Promise<string | null>} エラーメッセージ。未保存ならnull
      */
-    export function get(): Promise<string | null> {
-      return new Promise((resolve, reject) => {
-        chrome.storage.local.get([errorKey], (item) => {
-          const error = chrome.runtime.lastError;
-          if (error) {
-            reject(new Error(error.message));
-            return;
-          }
-          resolve((item[errorKey] as string | undefined) ?? null);
-        });
-      });
+    export async function get(): Promise<string | null> {
+      const item = await chrome.storage.local.get([errorKey]);
+      return (item[errorKey] as string | undefined) ?? null;
     }
   }
 

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -46,9 +46,8 @@ describe('App', (): void => {
       },
       storage: {
         local: {
-          set: (obj: { [key: string]: string }, cb: () => void): void => {
+          set: (obj: { [key: string]: string }): Promise<void> => {
             Object.assign(localData, obj);
-            cb();
             // 実際のChromeと同様に、変更をonChangedリスナーへ通知する
             for (const listener of onChangedListeners) {
               const changes: { [key: string]: chrome.storage.StorageChange } =
@@ -58,11 +57,9 @@ describe('App', (): void => {
               }
               listener(changes, 'local');
             }
+            return Promise.resolve();
           },
-          get: (
-            keys: string[],
-            cb: (items: { [key: string]: string }) => void,
-          ): void => {
+          get: (keys: string[]): Promise<{ [key: string]: string }> => {
             const res: { [key: string]: string } = {};
             for (const key of keys) {
               const value = localData[key];
@@ -70,11 +67,11 @@ describe('App', (): void => {
                 res[key] = value;
               }
             }
-            cb(res);
+            return Promise.resolve(res);
           },
-          remove: (key: string, cb: () => void): void => {
+          remove: (key: string): Promise<void> => {
             delete localData[key];
-            cb();
+            return Promise.resolve();
           },
         },
         sync: {

--- a/src/js/components/error.test.tsx
+++ b/src/js/components/error.test.tsx
@@ -59,14 +59,11 @@ describe('ErrorDisplay', (): void => {
       runtime: {},
       storage: {
         local: {
-          set: (obj: { [key: string]: string }, cb: () => void): void => {
+          set: (obj: { [key: string]: string }): Promise<void> => {
             Object.assign(localData, obj);
-            cb();
+            return Promise.resolve();
           },
-          get: (
-            keys: string[],
-            cb: (items: { [key: string]: string }) => void,
-          ): void => {
+          get: (keys: string[]): Promise<{ [key: string]: string }> => {
             const res: { [key: string]: string } = {};
             for (const key of keys) {
               const value = localData[key];
@@ -74,11 +71,11 @@ describe('ErrorDisplay', (): void => {
                 res[key] = value;
               }
             }
-            cb(res);
+            return Promise.resolve(res);
           },
-          remove: (key: string, cb: () => void): void => {
+          remove: (key: string): Promise<void> => {
             delete localData[key];
-            cb();
+            return Promise.resolve();
           },
         },
         onChanged: {


### PR DESCRIPTION
## 概要

fix #217

`src/js/chromeService.ts` の `chrome.storage.sync/local`・`chrome.tabs` に対するコールバック + `chrome.runtime.lastError` チェックによる手動 Promise ラップ（約10箇所）を、Manifest V3 の Promise 返却 API の直接呼び出しに置き換えました。

## 変更内容

- `new Promise` + `chrome.runtime.lastError` の手動ラップを chromeService から全廃（-145行/+42行）
- 公開関数のシグネチャ（`Promise` を返す点）は不変のため、呼び出し側の変更なし
- `errorLog.set` / `errorLog.clear` のコールバック内バッジ処理は `await` 後の実行に変更（エラー時にバッジが立たない挙動は維持）
- テスト（`chromeService.test.ts` / `app.test.tsx` / `error.test.tsx`）の chrome API モックをコールバック形式から Promise 形式へ更新

## 受け入れ条件の確認

- [x] `new Promise` + `chrome.runtime.lastError` の手動ラップが chromeService から消えている
- [x] エラー時に reject される挙動（errorLog 通知経路）が維持されている（テストあり）
- [x] `npm test`（50 passed）/ `npm run lint` / `npm run build` すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)