### PR TITLE
forEach+pushの反復処理をmap/flatMapに統合 (#215)

### DIFF
--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -12,15 +12,10 @@ export namespace blockService {
     createdAt: Date,
     index: number,
   ): model.Block {
-    const blockTabs: model.Tab[] = [];
-
-    tabs.forEach((tab) => {
-      const tabData: model.Tab = {
-        url: tab.url!,
-        title: tab.title!,
-      };
-      blockTabs.push(tabData);
-    });
+    const blockTabs: model.Tab[] = tabs.map((tab) => ({
+      url: tab.url!,
+      title: tab.title!,
+    }));
 
     return {
       indexNum: index,
@@ -59,14 +54,10 @@ export namespace blockService {
   export function jsonToBlock(json: string, indexNum: number): model.Block {
     const js = JSON.parse(json) as BlockJson;
 
-    const tabs: model.Tab[] = [];
-
-    js.tabs.forEach((jsonArr) => {
-      tabs.push({
-        url: jsonArr.url,
-        title: jsonArr.title,
-      });
-    });
+    const tabs: model.Tab[] = js.tabs.map((jsonArr) => ({
+      url: jsonArr.url,
+      title: jsonArr.title,
+    }));
 
     return {
       indexNum: indexNum,
@@ -135,17 +126,11 @@ export namespace blockService {
     json: BlockJson[],
     startIndex: number,
   ): model.Block[] {
-    let idx = startIndex;
-    return json.map((obj) => {
-      const o = jsonObjToBlock(obj, idx);
-      idx += 1;
-      return o;
-    });
+    return json.map((obj, i) => jsonObjToBlock(obj, startIndex + i));
   }
 
   export async function importAllDataJson(jsonStr: string): Promise<void> {
     const tabLength = await chromeService.storage.getTabLength();
-    const promiseArray: Promise<void>[] = [];
     const idx = tabLength;
 
     const json = JSON.parse(jsonStr);
@@ -164,11 +149,9 @@ export namespace blockService {
     }
     const blocks = blockListForJsonObject(blockObjs, idx);
 
-    blocks.forEach((block) => {
-      promiseArray.push(chromeService.storage.setBlock(block));
-    });
-
-    await Promise.all(promiseArray);
+    await Promise.all(
+      blocks.map((block) => chromeService.storage.setBlock(block)),
+    );
     await chromeService.storage.setTabLength(tabLength + blockObjs.length);
     chrome.tabs.reload({ bypassCache: true });
   }

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -82,18 +82,12 @@ export namespace chromeService {
         promiseArray.push(getSyncStorageReturnIndex(i));
       }
 
-      return Promise.all(promiseArray).then((result) => {
-        const nonEmptyArr = result.filter((obj) => {
-          return obj[1] != null && obj[1].length > 0;
-        });
-        const newBlocks: model.Block[] = [];
-        for (const arr of nonEmptyArr) {
-          const block = blockService.inflateJson(arr[1], arr[0]);
-          newBlocks.push(block);
-        }
-
-        return newBlocks.sort(sortBlock);
-      });
+      return Promise.all(promiseArray).then((result) =>
+        result
+          .filter((obj) => obj[1] != null && obj[1].length > 0)
+          .map((arr) => blockService.inflateJson(arr[1], arr[0]))
+          .sort(sortBlock),
+      );
     }
 
     const sortBlock = (a: model.Block, b: model.Block): number => {
@@ -113,18 +107,7 @@ export namespace chromeService {
     }
 
     export async function closeTabs(tabs: chrome.tabs.Tab[]): Promise<void> {
-      const promiseArray: Promise<void>[] = [];
-
-      for (const tab of tabs) {
-        promiseArray.push(closeTab(tab));
-      }
-
-      try {
-        await Promise.all(promiseArray);
-        return Promise.resolve();
-      } catch (err) {
-        return Promise.reject(err);
-      }
+      await Promise.all(tabs.map((tab) => closeTab(tab)));
     }
 
     export function queryTabs(

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -35,13 +35,11 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   };
 
   const openAllTab = () => {
-    const promiseArray: Promise<void>[] = [];
-    for (const tab of block.tabs) {
-      promiseArray.push(
+    Promise.all(
+      block.tabs.map((tab) =>
         chromeService.tab.createTabs({ url: tab.url, active: false }),
-      );
-    }
-    Promise.all(promiseArray)
+      ),
+    )
       .then(() => {
         deleteBlock();
       })


### PR DESCRIPTION
## 概要

issue #215 の対応。vercel-react-best-practices レビュー指摘（`js-combine-iterations` / `js-flatmap-filter`）に基づき、中間配列 + push や外部カウンタを使った反復処理を map ベースの式に置き換えました。挙動の変更はありません。

## 変更箇所

- `blockService.ts` `createBlock()` / `jsonToBlock()` — `forEach` + `push` → `map()`
- `blockService.ts` `blockListForJsonObject()` — 外部変数 `idx` のインクリメント → `map((obj, i) => jsonObjToBlock(obj, startIndex + i))`
- `blockService.ts` `importAllDataJson()` — `promiseArray` への push → `blocks.map()` を直接 `Promise.all` に渡す
- `chromeService.ts` `getAllBlock()` — `filter` → `for...of` + `push` の2パス → `filter().map().sort()` の1チェーン
- `chromeService.ts` `closeTabs()` / `block.tsx` `openAllTab()` — `for...of` + `push` → `map()`

## 確認

- `npm test` — 50件すべて通過
- `npm run lint` — 通過
- `npm run build` — 通過

Fixes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)