### PR TITLE
v0.5.0 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.5.0 (2026-08-05)
+
+- [NEW] タブを開く操作が失敗した際に、バッジとアラートでエラーを通知するように (#220)
+- [FIX] タブ一覧の key を配列 index 単体から URL との複合 key に変更し、並び替え時の再利用ミスを防止 (#218)
+- [UPDATE] 対応ブラウザを Chrome 110 以降に設定 (minimum_chrome_version) (#224)
+- [DEV] Block の再レンダリングを useCallback + React.memo で最適化 (#219)
+- [DEV] 条件レンダリングを && から三項演算子に統一 (#221)
+- [DEV] chromeService のコールバック手動 Promise 化を MV3 の Promise API に置き換え (#222)
+- [DEV] forEach+push の反復処理を map/filter().map() に統合、sort を非破壊の toSorted に変更 (#223, #224)
+
 # v0.4.2 (2026-08-04)
 
 - [FIX] 全データ削除後も一覧にブロックが表示されたままになる問題を修正 (#188)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v0.5.0 (2026-08-05)
 
+- [UPDATE] 対応ブラウザを Chrome 110 以降に設定 (minimum_chrome_version) (#224)
 - [NEW] タブを開く操作が失敗した際に、バッジとアラートでエラーを通知するように (#220)
 - [FIX] タブ一覧の key を配列 index 単体から URL との複合 key に変更し、並び替え時の再利用ミスを防止 (#218)
-- [UPDATE] 対応ブラウザを Chrome 110 以降に設定 (minimum_chrome_version) (#224)
 - [DEV] Block の再レンダリングを useCallback + React.memo で最適化 (#219)
 - [DEV] 条件レンダリングを && から三項演算子に統一 (#221)
 - [DEV] chromeService のコールバック手動 Promise 化を MV3 の Promise API に置き換え (#222)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SyncTabClipper",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "manifest_version": 3,
   "minimum_chrome_version": "110",
   "description": "__MSG_Description__",


### PR DESCRIPTION
## 概要

v0.5.0 のリリース準備として、バージョン更新と CHANGELOG 追記を行う。

- `src/manifest.json` の version を 0.4.2 → 0.5.0 に更新
- CHANGELOG.md に v0.5.0 の変更内容を追記

## v0.5.0 に含まれる変更 (v0.4.2 以降)

- [NEW] タブを開く操作が失敗した際に、バッジとアラートでエラーを通知するように (#220)
- [FIX] タブ一覧の key を配列 index 単体から URL との複合 key に変更 (#218)
- [UPDATE] 対応ブラウザを Chrome 110 以降に設定 (#224)
- [DEV] React ベストプラクティス対応のリファクタリング (#219, #221, #222, #223, #224)

## 検証

- `npm test`: 50 件すべてパス
- `npm run build`: 成功。dist/manifest.json に version 0.5.0 が反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)