### PR TITLE
getDomain の URL 判定を URL.canParse に置き換え、対応 Chrome を 120 以降に

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [UPDATE] 対応ブラウザを Chrome 120 以降に変更 (minimum_chrome_version)、URL 判定を try/catch から `URL.canParse` に置き換え
+
 # v0.5.1 (2026-08-11)
 
 - [FIX] 読み込めない保存データが 1 件あるとタブ一覧全体が表示されなくなる問題を修正 (#192, #230)

--- a/src/js/util.test.ts
+++ b/src/js/util.test.ts
@@ -1,9 +1,7 @@
 /**
  * @jest-environment jsdom
  *
- * node環境のURLはURLでない文字列に対しcode: 'ERR_INVALID_URL'を持つエラーを投げるが、
- * ブラウザのURLはcodeを持たないTypeErrorを投げる。この差でnode環境のテストは
- * 実挙動を検証できないため、拡張機能と同じjsdomで検証する
+ * URLの解釈はnode環境とブラウザで挙動が異なるため、拡張機能と同じjsdomで検証する
  */
 import { util } from './util';
 

--- a/src/js/util.ts
+++ b/src/js/util.ts
@@ -7,15 +7,10 @@ export namespace util {
    * @return {string} strのドメイン部分 or 空文字列
    */
   export function getDomain(str: string): string {
-    // URL.canParseはChrome 120以降で、manifestのminimum_chrome_version(110)では
-    // 使えないためtry/catchで判定する。ブラウザのURLはcodeを持たないTypeErrorを
-    // 投げるため、エラーの種類で分岐せず一律で空文字列を返す
-    try {
-      const parser = new URL(str);
-      return parser.hostname;
-    } catch {
+    if (!URL.canParse(str)) {
       return '';
     }
+    return new URL(str).hostname;
   }
 
   /**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "name": "SyncTabClipper",
   "version": "0.5.1",
   "manifest_version": 3,
-  "minimum_chrome_version": "110",
+  "minimum_chrome_version": "120",
   "description": "__MSG_Description__",
   "default_locale": "en",
   "permissions": ["tabs", "storage", "contextMenus"],


### PR DESCRIPTION
## 概要

`util.getDomain` に残っていた「`URL.canParse` は Chrome 120 以降で、`minimum_chrome_version` (110) では使えない」という制約に対応した。`minimum_chrome_version` を 120 に上げ、try/catch による代替判定を `URL.canParse` に置き換えた。

## 変更内容

- `src/manifest.json`: `minimum_chrome_version` を `110` → `120`
- `src/js/util.ts`: `getDomain` を `URL.canParse` で実装（try/catch を廃止）
- `src/js/util.test.ts`: node と browser で投げるエラーが異なる旨の説明を削除（例外を投げなくなったため）。jsdom 環境の指定は実行環境と揃えるため維持
- `CHANGELOG.md`: Unreleased に記載

## 影響

Chrome 110〜119 のユーザーは以降のバージョンの配信対象外になる。

## 検証

- `npx tsc --noEmit`: エラーなし
- `npx jest`: 8 suites / 81 tests pass（`getDomain` の異常系 5 ケース含む。`'https://'` も `canParse` が false のため空文字列のまま）
- `npm run lint` / `npm run format:check`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)