### PR TITLE
v0.6.0 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# Unreleased
+# v0.6.0 (2026-08-11)
 
-- [UPDATE] 対応ブラウザを Chrome 120 以降に変更 (minimum_chrome_version)、URL 判定を try/catch から `URL.canParse` に置き換え
+- [UPDATE] 対応ブラウザを Chrome 120 以降に変更 (minimum_chrome_version)、URL 判定を try/catch から `URL.canParse` に置き換え (#234)
+- [UPDATE] 「すべてのデータを削除する」をメニュー末尾の折りたたみ式「上級者向け」サブメニューへ移動し、警告色と注意書きを追加 (#207, #208)
+- [FIX] ブラウザがダークテーマのときツールバーアイコンが視認しづらい問題を修正 (半透明白の縁取りを追加、アイコンを 16/32/48/128 の全サイズ登録) (#193, #198)
+- [DEV] uikit を 3.25.21 に更新 (#231)
 
 # v0.5.1 (2026-08-11)
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SyncTabClipper",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "manifest_version": 3,
   "minimum_chrome_version": "120",
   "description": "__MSG_Description__",


### PR DESCRIPTION
v0.5.1 からの差分を v0.6.0 としてリリースするための準備です。

## 変更内容

- `src/manifest.json` の `version` を `0.5.1` → `0.6.0`
- `CHANGELOG.md` の `# Unreleased` を `# v0.6.0 (2026-08-11)` として確定し、未記載だった変更を追記

## v0.6.0 に含まれる変更 (v0.5.1..master)

| PR | 種別 | 内容 |
| --- | --- | --- |
| #234 | UPDATE | 対応ブラウザを Chrome 120 以降に変更、URL 判定を `URL.canParse` に置き換え |
| #208 (closes #207) | UPDATE | 「すべてのデータを削除する」を折りたたみ式「上級者向け」サブメニューへ移動し、警告色と注意書きを追加 |
| #198 (closes #193) | FIX | ダークテーマでツールバーアイコンが視認しづらい問題を修正（半透明白の縁取り、アイコンを 16/32/48/128 の全サイズ登録） |
| #231 | DEV | uikit を 3.25.21 に更新 |

破壊的変更はありませんが、`minimum_chrome_version` の引き上げ（110 → 120）とメニュー構成の変更を含むため minor bump としています。

## 確認

- `npm test`: 8 suites / 81 tests すべて成功
- `npm run lint`: pass
- `npm run format:check`: pass
- `npm run build:prod`: 成功。`dist/manifest.json` の version が `0.6.0` であることを確認

## マージ後の TODO

- [ ] `v0.6.0` タグ作成
- [ ] `archive.zip` を Chrome Web Store へ申請
- [ ] worktree の後始末

🤖 Generated with [Claude Code](https://claude.com/claude-code)
