### PR TITLE
Dependabot に GitHub Actions の更新設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
## 概要
既存の Dependabot 設定に GitHub Actions の更新設定を追加し、あわせて更新間隔を `weekly` に統一します。ワークフローは存在するものの、`github-actions` エコシステムが対象外になっていました。

## 変更内容
- `.github/dependabot.yml` に `package-ecosystem: github-actions`（weekly）を追加
- 既存定義の `interval: daily` を `interval: weekly` に変更（アカウント内の他リポジトリと統一）
- それ以外のオプションは変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)