### PR TITLE
保存したブロックの編集をロックできるようにする

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -120,6 +120,9 @@
   "content_msg_lock_block_save_failed": {
     "message": "Failed to change the lock. Please try again."
   },
+  "content_msg_locked_badge": {
+    "message": "Locked"
+  },
   "content_msg_locked_action_disabled": {
     "message": "Not available while this block is locked"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -81,6 +81,9 @@
   "content_msg_edit_tab": {
     "message": "Edit"
   },
+  "content_msg_delete_tab": {
+    "message": "Delete"
+  },
   "content_msg_edit_tab_heading": {
     "message": "Edit link"
   },
@@ -116,6 +119,12 @@
   },
   "content_msg_lock_block_save_failed": {
     "message": "Failed to change the lock. Please try again."
+  },
+  "content_msg_locked_action_disabled": {
+    "message": "Not available while this block is locked"
+  },
+  "content_msg_locked_block_delete_confirm": {
+    "message": "This block was locked, but the lock cannot be released because its data cannot be displayed. Deleting it removes it from all synced devices. Delete it?"
   },
   "content_msg_edit_block_title_label": {
     "message": "Block name"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -108,6 +108,15 @@
   "content_msg_edit_block_title": {
     "message": "Edit name"
   },
+  "content_msg_lock_block": {
+    "message": "Lock editing"
+  },
+  "content_msg_unlock_block": {
+    "message": "Unlock editing"
+  },
+  "content_msg_lock_block_save_failed": {
+    "message": "Failed to change the lock. Please try again."
+  },
   "content_msg_edit_block_title_label": {
     "message": "Block name"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -120,6 +120,9 @@
   "content_msg_lock_block_save_failed": {
     "message": "ロックの変更に失敗しました。もう一度お試しください。"
   },
+  "content_msg_locked_badge": {
+    "message": "ロック中"
+  },
   "content_msg_locked_action_disabled": {
     "message": "ロック中のため操作できません"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -108,6 +108,15 @@
   "content_msg_edit_block_title": {
     "message": "名前を編集"
   },
+  "content_msg_lock_block": {
+    "message": "編集をロックする"
+  },
+  "content_msg_unlock_block": {
+    "message": "編集のロックを解除する"
+  },
+  "content_msg_lock_block_save_failed": {
+    "message": "ロックの変更に失敗しました。もう一度お試しください。"
+  },
   "content_msg_edit_block_title_label": {
     "message": "ブロックの名前"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -81,6 +81,9 @@
   "content_msg_edit_tab": {
     "message": "編集"
   },
+  "content_msg_delete_tab": {
+    "message": "削除"
+  },
   "content_msg_edit_tab_heading": {
     "message": "リンクを編集"
   },
@@ -116,6 +119,12 @@
   },
   "content_msg_lock_block_save_failed": {
     "message": "ロックの変更に失敗しました。もう一度お試しください。"
+  },
+  "content_msg_locked_action_disabled": {
+    "message": "ロック中のため操作できません"
+  },
+  "content_msg_locked_block_delete_confirm": {
+    "message": "このブロックは編集をロックしていましたが、データを表示できないためロックを解除できません。削除するとすべての同期端末から消えます。削除しますか？"
   },
   "content_msg_edit_block_title_label": {
     "message": "ブロックの名前"

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -136,10 +136,21 @@
   margin: 0 0 8px;
 }
 
-/* 名前の編集中やタブの書き換え中は切り替えさせないため、押せないと分かるようにする */
-.block-lock-toggle:disabled {
+/*
+ * 押せないボタンの見せ方。UIkitの`.uk-link` / `.uk-icon`がcolorを指定して
+ * いるためブラウザ既定のdisabled表現は出ず、有効時と同じ見た目になる。
+ * hoverの色と下線も残るので明示的に打ち消す
+ */
+.block-lock-toggle:disabled,
+.block-title-edit:disabled {
   opacity: 0.5;
   cursor: default;
+}
+
+.block-lock-toggle:disabled:hover,
+.block-title-edit:disabled:hover {
+  color: inherit;
+  text-decoration: none;
 }
 
 /*
@@ -154,6 +165,14 @@
 .all_tab_delete[aria-disabled='true'] {
   opacity: 0.5;
   cursor: default;
+}
+
+/* uk-linkのhoverが残ると、押せないのに色が変わって押せるように見える */
+.tab_edit[aria-disabled='true']:hover,
+.tab_close[aria-disabled='true']:hover,
+.all_tab_delete[aria-disabled='true']:hover {
+  color: inherit;
+  text-decoration: none;
 }
 
 /*

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -137,6 +137,52 @@
 }
 
 /*
+ * ロック中のブロックの見せ方 (#194)
+ *
+ * アイコンの形（lock / unlock）だけでは一覧を眺めたときに区別が付かないので、
+ * カードの縁・ヘッダの地色・バッジ・ボタンの反転の4点で状態を示す。
+ * UIkitのprimary #1e87f0 は白背景に対するコントラスト比が約3.2:1しかなく
+ * バッジの文字には足りないため、同系でより濃い色を専用に定義する。
+ */
+.block-root-dom[data-locked='true'] {
+  border-left: 4px solid #1a5fa0;
+}
+
+.block-root-dom[data-locked='true'] > .uk-card-header {
+  background: #eef4fb;
+}
+
+.block-locked-badge-row {
+  margin-bottom: 4px;
+}
+
+.block-locked-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 10px 1px 8px;
+  border-radius: 10px;
+  background: #1a5fa0;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.6;
+}
+
+/* ロック中はボタン自体も塗り分けて、解除の的だと分かるようにする */
+.block-lock-toggle[data-locked='true'] {
+  color: #fff;
+  background: #1a5fa0;
+  border-radius: 50%;
+}
+
+.block-lock-toggle[data-locked='true']:hover,
+.block-lock-toggle[data-locked='true']:focus {
+  color: #fff;
+  background: #14487a;
+}
+
+/*
  * 押せないボタンの見せ方。UIkitの`.uk-link` / `.uk-icon`がcolorを指定して
  * いるためブラウザ既定のdisabled表現は出ず、有効時と同じ見た目になる。
  * hoverの色と下線も残るので明示的に打ち消す

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -136,12 +136,22 @@
   margin: 0 0 8px;
 }
 
+/* 名前の編集中やタブの書き換え中は切り替えさせないため、押せないと分かるようにする */
+.block-lock-toggle:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 /*
  * ロック中に止めた操作。inertと違いクリックハンドラを外しているだけなので、
  * 押せなくなったことが見て分かるよう、inertの見せ方（淡色）に揃える。
- * uk-linkを外しているためポインタも既定に戻す
+ * classNameではなくaria-disabledを見るのは、data-uk-iconを持つ要素の
+ * classNameをReactに書き換えさせるとUIkitが付けたuk-iconごと消え、
+ * アイコンの色と行の高さが崩れたまま戻らないため
  */
-.tab-action-disabled {
+.tab_edit[aria-disabled='true'],
+.tab_close[aria-disabled='true'],
+.all_tab_delete[aria-disabled='true'] {
   opacity: 0.5;
   cursor: default;
 }

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -140,26 +140,17 @@
  * ロック中のブロックの見せ方 (#194)
  *
  * アイコンの形（lock / unlock）だけでは一覧を眺めたときに区別が付かないので、
- * カードの縁・ヘッダの地色・バッジ・ボタンの反転の4点で状態を示す。
+ * バッジとボタンの塗り分けの2点で状態を示す。カードの縁やヘッダの地色まで
+ * 変えると一覧が騒がしくなるため、カード本体の見た目は変えない。
  * UIkitのprimary #1e87f0 は白背景に対するコントラスト比が約3.2:1しかなく
  * バッジの文字には足りないため、同系でより濃い色を専用に定義する。
  */
-.block-root-dom[data-locked='true'] {
-  border-left: 4px solid #1a5fa0;
-}
-
-.block-root-dom[data-locked='true'] > .uk-card-header {
-  background: #eef4fb;
-}
-
-.block-locked-badge-row {
-  margin-bottom: 4px;
-}
-
 .block-locked-badge {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  /* 見出しと同じ行に並ぶため、見出しの文字サイズを継がずに固定する */
+  margin-left: 8px;
   padding: 1px 10px 1px 8px;
   border-radius: 10px;
   background: #1a5fa0;
@@ -167,6 +158,9 @@
   font-size: 12px;
   font-weight: 700;
   line-height: 1.6;
+  vertical-align: middle;
+  /* 長い名前で折り返しても「ロック中」が分断されないようにする */
+  white-space: nowrap;
 }
 
 /* ロック中はボタン自体も塗り分けて、解除の的だと分かるようにする */

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -104,6 +104,49 @@
 }
 
 /*
+ * ブロックの編集ロック (#194)
+ *
+ * ロックの切り替えはカード全体に効く操作なので、見出しや個々のタブの操作より
+ * 上位にあることが分かるよう、カードヘッダの右上に置く。
+ * 見出しの下へ回り込ませたくないため絶対配置にし、
+ * 長い名前がボタンの下へ潜り込まないようヘッダに右余白を確保する。
+ */
+.block-card-header {
+  position: relative;
+  padding-right: 44px;
+}
+
+.block-lock-toggle {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  /* アイコン(ratio 0.9で約18px)だけではクリックの的が小さいので、
+     ブロックを守る操作として押しやすい大きさを確保する */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  min-height: 24px;
+  padding: 0;
+  border: none;
+  background: none;
+}
+
+.block-lock-error {
+  margin: 0 0 8px;
+}
+
+/*
+ * ロック中に止めた操作。inertと違いクリックハンドラを外しているだけなので、
+ * 押せなくなったことが見て分かるよう、inertの見せ方（淡色）に揃える。
+ * uk-linkを外しているためポインタも既定に戻す
+ */
+.tab-action-disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/*
  * 名前を編集している間は、カードのタブ一覧と操作リンクをinertで止めている。
  * タブの編集モーダルはオーバーレイが背後を覆うので無効だと分かるが、
  * 名前のインライン編集にはオーバーレイがない。ブラウザはinertを淡色化しない

--- a/src/js/blockService.test.ts
+++ b/src/js/blockService.test.ts
@@ -245,6 +245,20 @@ describe('blockService', (): void => {
     });
   });
 
+  // インポートやv1の非圧縮データはjsonObjToBlock経由で読むため、
+  // jsonToBlockとは別の入口になる
+  test('inflateJson 非圧縮のデータからもロックを読む', async (): Promise<void> => {
+    const json =
+      '{"v":3,"ev":"9.9.9","created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}],"locked":true}';
+
+    await expect(blockService.inflateJson(json, 1)).resolves.toStrictEqual({
+      indexNum: 1,
+      createdAt: new Date(`2021-01-02T03:04:05.678Z`),
+      tabs: [{ url: 'https://example.com/test', title: 'title-test' }],
+      locked: true,
+    });
+  });
+
   // インポートしたJSONには型の検証がないため、lockedにも何でも入りうる。
   // truthyな値を拾うと"false"の文字列でロックされ、UIからは解除できるものの
   // 保存のたびに同じ値が往復するわけではない点も含めて紛らわしい。

--- a/src/js/blockService.test.ts
+++ b/src/js/blockService.test.ts
@@ -199,6 +199,75 @@ describe('blockService', (): void => {
     });
   });
 
+  test('blockToJson ロックしているブロックはlockedを含める', (): void => {
+    const block = {
+      indexNum: 1,
+      createdAt: new Date(`2021-01-02T03:04:05.678Z`),
+      tabs: [{ url: 'https://example.com/test', title: 'title-test' }],
+      locked: true,
+    };
+
+    expect(blockService.blockToJson(block)).toBe(
+      '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}],"locked":true}',
+    );
+  });
+
+  // ロックしていないブロックにキーを増やさない。storage.syncの8KB/item制限を
+  // 圧迫しないためと、ロックを知らなかった頃のデータと同じ形を保つため
+  test.each([
+    ['ロックしていない', false],
+    ['ロックしたことがない', undefined],
+  ])(
+    'blockToJson %sブロックはlockedを含めない',
+    (_name: string, locked: boolean | undefined): void => {
+      const block = {
+        indexNum: 1,
+        createdAt: new Date(`2021-01-02T03:04:05.678Z`),
+        tabs: [{ url: 'https://example.com/test', title: 'title-test' }],
+        locked: locked,
+      };
+
+      expect(blockService.blockToJson(block)).toBe(
+        '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}]}',
+      );
+    },
+  );
+
+  test('jsonToBlock ロックを読む', (): void => {
+    const json =
+      '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}],"locked":true}';
+
+    expect(blockService.jsonToBlock(json, 1)).toStrictEqual({
+      indexNum: 1,
+      createdAt: new Date(`2021-01-02T03:04:05.678Z`),
+      tabs: [{ url: 'https://example.com/test', title: 'title-test' }],
+      locked: true,
+    });
+  });
+
+  // インポートしたJSONには型の検証がないため、lockedにも何でも入りうる。
+  // truthyな値を拾うと"false"の文字列でロックされ、UIからは解除できるものの
+  // 保存のたびに同じ値が往復するわけではない点も含めて紛らわしい。
+  // 真偽値のtrueだけをロックとみなす
+  test.each([
+    ['文字列のfalse', '"false"'],
+    ['文字列のtrue', '"true"'],
+    ['数値の1', '1'],
+    ['false', 'false'],
+    ['null', 'null'],
+  ])(
+    'jsonToBlock ロックとして扱えないlocked(%s)はロックなしとして読む',
+    (_name: string, lockedJson: string): void => {
+      const json = `{"created_at":1609556645678,"tabs":[{"url":"https://example.com/test","title":"title-test"}],"locked":${lockedJson}}`;
+
+      expect(blockService.jsonToBlock(json, 1)).toStrictEqual({
+        indexNum: 1,
+        createdAt: new Date(`2021-01-02T03:04:05.678Z`),
+        tabs: [{ url: 'https://example.com/test', title: 'title-test' }],
+      });
+    },
+  );
+
   // 数値になった名前は直せる情報なので、捨てずに文字列として見せる
   test('jsonToBlock 数値のtitleは文字列として読む', (): void => {
     const json =

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -62,6 +62,9 @@ export namespace blockService {
       // 名前のないブロックにキーを増やさない。storage.syncの8KB/item制限を
       // titleで圧迫しないためと、名前を持たない従来のデータと同じ形を保つため
       ...(block.title == null ? {} : { title: block.title }),
+      // ロックしていないブロックも同様にキーを作らない。
+      // falseを書いてもロックしていないことしか意味せず、既定値と同じ
+      ...(block.locked === true ? { locked: true } : {}),
     };
   }
 
@@ -74,10 +77,15 @@ export namespace blockService {
   // なお一覧はstorage.onChangedを購読していないため、tabs.htmlを複数枚開くと
   // 同じバージョンでも古い一覧からの書き戻しで名前が消える。これは同じ状況で
   // タブの増減が打ち消し合うのと同根の既存の課題で、titleに固有のものではない
+  // lockedもtitleと同じく、スキーマ版数を上げずに追加した省略可能なフィールド。
+  // lockedを知らない旧バージョンが同じブロックを書き戻すとロックは失われるが、
+  // 版数を上げて旧バージョンから一切表示できなくするより軽い副作用とみなす。
+  // ロックはこの拡張機能のUIの誤操作を防ぐもので、データの改変を保証する仕組みではない
   type BlockJson = {
     created_at: number;
     tabs: model.Tab[];
     title?: string;
+    locked?: boolean;
     v?: number;
     d?: string;
   };
@@ -138,12 +146,26 @@ export namespace blockService {
     return blockTitle == null ? {} : { title: blockTitle };
   }
 
+  /**
+   * ブロックへロック状態を載せる。ロックしていないときはlockedのキー自体を
+   * 作らず、ロックを知らなかった頃のブロックと同じ形を保つ。
+   * titleと同じくインポートしたJSONには型の検証がないため、
+   * 真偽値のtrue以外はロックとみなさない（"false"のような文字列を
+   * truthyとして拾うと、解除できないブロックができてしまう）
+   * @param {unknown} locked 保存データが持っていたlocked
+   * @return {object} lockedを持つオブジェクト。ロックしていなければ空オブジェクト
+   */
+  function blockLockedField(locked: unknown): { locked?: boolean } {
+    return locked === true ? { locked: true } : {};
+  }
+
   function jsonObjToBlock(object: BlockJson, index: number): model.Block {
     return {
       indexNum: index,
       createdAt: toCreatedAt(object.created_at),
       tabs: object.tabs,
       ...blockTitleField(object.title),
+      ...blockLockedField(object.locked),
     };
   }
 
@@ -164,6 +186,7 @@ export namespace blockService {
       createdAt: toCreatedAt(js.created_at),
       tabs: tabs,
       ...blockTitleField(js.title),
+      ...blockLockedField(js.locked),
     };
   }
 

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -319,6 +319,56 @@ describe('App', (): void => {
     }
   });
 
+  // 描画に失敗したロック済みブロックはロックを解除する導線ごと失われるため、
+  // 差し替わったカードの削除ボタンが保護を素通りしないようにする(#194)
+  test('ロックしたブロックがレンダリングで落ちたら削除前に警告する', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([
+      {
+        indexNum: 0,
+        // createdAtが不正なDateだとblock.tsxのtoISOString()がRangeErrorを投げる
+        createdAt: new Date('invalid'),
+        tabs: [{ url: 'https://example.com/locked', title: 'title-locked' }],
+        locked: true,
+      },
+    ]);
+    const removeBlockSpy = jest
+      .spyOn(chromeService.storage, 'removeBlock')
+      .mockResolvedValue(undefined);
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    // Reactが境界で捕捉した例外をconsole.errorへ出力するため抑止する
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    try {
+      await mount();
+
+      const deleteLink = container.querySelector(
+        '.broken_block_delete',
+      ) as HTMLElement;
+      await act(async () => {
+        deleteLink.click();
+      });
+
+      expect(confirmSpy).toHaveBeenCalledWith(
+        'content_msg_locked_block_delete_confirm',
+      );
+      expect(removeBlockSpy).not.toHaveBeenCalled();
+
+      // 警告を承諾したときだけ削除する
+      confirmSpy.mockReturnValue(true);
+      await act(async () => {
+        deleteLink.click();
+      });
+
+      expect(removeBlockSpy).toHaveBeenCalledWith(0);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      confirmSpy.mockRestore();
+      removeBlockSpy.mockRestore();
+    }
+  });
+
   test('復元できなかったブロックはカードとして表示され削除できる', async (): Promise<void> => {
     getAllBlockSpy.mockResolvedValue([
       {

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -956,10 +956,11 @@ describe('Block 編集のロック', (): void => {
 
     const editIcon = container.querySelector<HTMLElement>('.tab_edit')!;
     const closeIcon = container.querySelector<HTMLElement>('.tab_close')!;
-    // 未ロックのときと同じclassName（uk-linkを外して別のクラスに
-    // 差し替えると、UIkitが付けたuk-iconごと消える）
-    expect(editIcon.className).toBe('uk-link tab_edit');
-    expect(closeIcon.className).toBe('uk-link tab_close');
+    // 未ロックのときと同じclassNameであることを見る。ロックで差し替えると
+    // UIkitが付けたuk-iconごとReactに書き換えられるため。
+    // uk-iconの保全そのものはUIkitを動かしていないjsdomでは検証できない
+    expect(editIcon.classList.contains('uk-link')).toBe(true);
+    expect(closeIcon.classList.contains('uk-link')).toBe(true);
     expect(editIcon.getAttribute('aria-disabled')).toBe('true');
     expect(closeIcon.getAttribute('aria-disabled')).toBe('true');
   });

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -864,9 +864,10 @@ describe('Block 編集のロック', (): void => {
 
     await clickLockToggle();
 
-    expect(updateBlock).toHaveBeenCalledWith(
-      expect.objectContaining({ locked: undefined }),
-    );
+    // objectContainingはキーの有無を区別しないため、値そのものを確かめる
+    // （lockedを持ったまま渡すとblockToJsonObjが"locked":trueを書き続ける）
+    expect(updateBlock).toHaveBeenCalledTimes(1);
+    expect(updateBlock.mock.calls[0][0].locked).toBeUndefined();
   });
 
   // App側のアラートはページ最上部に出るため、スクロール中は気付けない。
@@ -926,7 +927,9 @@ describe('Block 編集のロック', (): void => {
     expect(updateBlock).not.toHaveBeenCalled();
   });
 
-  test('ロックの状態をアイコンとaria-pressedで伝える', async (): Promise<void> => {
+  // 見えているツールチップと支援技術に伝わる名前が食い違うと、
+  // 音声操作でツールチップの文言を読み上げても操作できない
+  test('ロックの状態をアイコンと名前で伝える', async (): Promise<void> => {
     const updateBlock = jest.fn().mockResolvedValue(undefined);
     await mount(
       [{ url: 'https://example.com/a', title: 'title-a' }],
@@ -936,8 +939,29 @@ describe('Block 編集のロック', (): void => {
 
     const button =
       container.querySelector<HTMLButtonElement>('.block-lock-toggle')!;
-    expect(button.getAttribute('aria-pressed')).toBe('true');
     expect(button.getAttribute('data-uk-icon')).toBe('icon: lock; ratio: 0.9');
+    expect(button.getAttribute('title')).toBe('content_msg_unlock_block');
+    expect(button.getAttribute('aria-label')).toBe('content_msg_unlock_block');
+  });
+
+  // data-uk-iconを持つ要素のclassNameをロックで切り替えると、UIkitが付けた
+  // uk-iconごとReactに書き換えられ、アイコンの色と行の高さが崩れたまま戻らない
+  test('ロック中もアイコンのclassNameは変えず、無効はaria-disabledで表す', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+      true,
+    );
+
+    const editIcon = container.querySelector<HTMLElement>('.tab_edit')!;
+    const closeIcon = container.querySelector<HTMLElement>('.tab_close')!;
+    // 未ロックのときと同じclassName（uk-linkを外して別のクラスに
+    // 差し替えると、UIkitが付けたuk-iconごと消える）
+    expect(editIcon.className).toBe('uk-link tab_edit');
+    expect(closeIcon.className).toBe('uk-link tab_close');
+    expect(editIcon.getAttribute('aria-disabled')).toBe('true');
+    expect(closeIcon.getAttribute('aria-disabled')).toBe('true');
   });
 
   // ロックの書き込みが着地するまでpropsのlockedは古いままで、その間に

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -885,6 +885,90 @@ describe('Block 編集のロック', (): void => {
     expect(error.getAttribute('role')).toBe('alert');
   });
 
+  test('ロック中はタブの編集・削除アイコンを押しても何も起きない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [
+        { url: 'https://example.com/a', title: 'title-a' },
+        { url: 'https://example.com/b', title: 'title-b' },
+      ],
+      updateBlock,
+      true,
+    );
+
+    await act(async () => {
+      container.querySelectorAll<HTMLElement>('.tab_edit')[0]!.click();
+      container.querySelectorAll<HTMLElement>('.tab_close')[0]!.click();
+    });
+
+    expect(updateBlock).not.toHaveBeenCalled();
+    expect(container.querySelector('.edit-tab-modal')).toBeNull();
+    expect(container.querySelectorAll('a.tab_link')).toHaveLength(2);
+  });
+
+  // 壊れたタブの削除もタブ配列の書き換えなので、ロック中は止める
+  test('ロック中は壊れたタブも削除できない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [
+        // urlを持たないタブは壊れたタブとして表示される
+        { title: 'broken' } as unknown as model.Tab,
+        { url: 'https://example.com/b', title: 'title-b' },
+      ],
+      updateBlock,
+      true,
+    );
+
+    await act(async () => {
+      container.querySelector<HTMLElement>('.broken_tab_close')!.click();
+    });
+
+    expect(updateBlock).not.toHaveBeenCalled();
+  });
+
+  test('ロックの状態をアイコンとaria-pressedで伝える', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+      true,
+    );
+
+    const button =
+      container.querySelector<HTMLButtonElement>('.block-lock-toggle')!;
+    expect(button.getAttribute('aria-pressed')).toBe('true');
+    expect(button.getAttribute('data-uk-icon')).toBe('icon: lock; ratio: 0.9');
+  });
+
+  // ロックの書き込みが着地するまでpropsのlockedは古いままで、その間に
+  // 始まったタブ操作はロックを知らないまま書き戻す。tabs:[]の書き戻しは
+  // storage側でブロックの削除になるため、ロックしたばかりのブロックが消える
+  test('ロックの保存中はタブを書き換える導線が止まる', async (): Promise<void> => {
+    // 決着させないPromiseを返して保存中の状態に留める
+    const updateBlock = jest.fn().mockReturnValue(new Promise<void>(() => {}));
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+    );
+
+    await clickLockToggle();
+
+    expect(updateBlock).toHaveBeenCalledTimes(1);
+    expect(
+      container
+        .querySelector('.uk-card-header .uk-grid')!
+        .hasAttribute('inert'),
+    ).toBe(true);
+    expect(
+      container.querySelector('.uk-card-body')!.hasAttribute('inert'),
+    ).toBe(true);
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('.block-title-edit')!
+        .hasAttribute('disabled'),
+    ).toBe(true);
+  });
+
   // ロックもブロックごと書き戻すため、名前の編集と並行すると
   // 後から着地した側が相手の変更を打ち消す
   test('名前を編集している間はロックを切り替えられない', async (): Promise<void> => {

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -711,3 +711,199 @@ describe('Block タブ操作と名前の編集の排他', (): void => {
     expect(createTabsSpy).not.toHaveBeenCalled();
   });
 });
+
+// ロックはブロックを誤って削除・変更しないための保護(#194)。
+// 「URLを開いてもブロックを消さない」「削除・編集系の導線を止める」の2点を守る
+describe('Block 編集のロック', (): void => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let createTabsSpy: jest.SpyInstance;
+
+  const mount = async (
+    tabs: model.Tab[],
+    updateBlock: (newBlock: model.Block) => Promise<void>,
+    locked?: boolean,
+    title?: string,
+  ): Promise<void> => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Block
+          block={{
+            indexNum: 0,
+            createdAt: new Date('2021-01-02T03:04:05.678Z'),
+            tabs: tabs,
+            title: title,
+            locked: locked,
+          }}
+          updateBlock={updateBlock}
+        />,
+      );
+    });
+  };
+
+  const clickLockToggle = async (): Promise<void> => {
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.block-lock-toggle')!.click();
+    });
+  };
+
+  beforeEach((): void => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      i18n: {
+        getMessage: (key: string): string => key,
+      },
+    };
+    createTabsSpy = jest
+      .spyOn(chromeService.tab, 'createTabs')
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach((): void => {
+    act(() => root.unmount());
+    container.remove();
+    createTabsSpy.mockRestore();
+  });
+
+  test('ロック中はリンクを開いてもタブを一覧から消さない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+      true,
+    );
+
+    await act(async () => {
+      container.querySelector<HTMLAnchorElement>('a.tab_link')!.click();
+    });
+
+    expect(createTabsSpy).toHaveBeenCalledWith({
+      url: 'https://example.com/a',
+      active: false,
+    });
+    expect(updateBlock).not.toHaveBeenCalled();
+    expect(container.querySelectorAll('a.tab_link')).toHaveLength(1);
+  });
+
+  test('ロック中は「すべてのリンクを開く」でもタブを一覧から消さない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [
+        { url: 'https://example.com/a', title: 'title-a' },
+        { url: 'https://example.com/b', title: 'title-b' },
+      ],
+      updateBlock,
+      true,
+    );
+
+    await act(async () => {
+      container.querySelector<HTMLElement>('.all_tab_link')!.click();
+    });
+
+    expect(createTabsSpy).toHaveBeenCalledTimes(2);
+    expect(updateBlock).not.toHaveBeenCalled();
+  });
+
+  test('ロック中は「すべてのリンクを閉じる」と名前の編集を止める', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+      true,
+    );
+
+    await act(async () => {
+      container.querySelector<HTMLElement>('.all_tab_delete')!.click();
+      container.querySelector<HTMLButtonElement>('.block-title-edit')!.click();
+    });
+
+    expect(updateBlock).not.toHaveBeenCalled();
+    expect(container.querySelector('.block-title-input')).toBeNull();
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('.block-title-edit')!
+        .hasAttribute('disabled'),
+    ).toBe(true);
+    expect(
+      container
+        .querySelector<HTMLElement>('.all_tab_delete')!
+        .getAttribute('aria-disabled'),
+    ).toBe('true');
+  });
+
+  test('ロックしてもタブと名前を保ったままupdateBlockを呼ぶ', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+      undefined,
+      '調査中のタブ',
+    );
+
+    await clickLockToggle();
+
+    expect(updateBlock).toHaveBeenCalledWith({
+      indexNum: 0,
+      createdAt: new Date('2021-01-02T03:04:05.678Z'),
+      tabs: [{ url: 'https://example.com/a', title: 'title-a' }],
+      title: '調査中のタブ',
+      locked: true,
+    });
+  });
+
+  test('ロックを解除するとlockedを落としてupdateBlockを呼ぶ', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+      true,
+    );
+
+    await clickLockToggle();
+
+    expect(updateBlock).toHaveBeenCalledWith(
+      expect.objectContaining({ locked: undefined }),
+    );
+  });
+
+  // App側のアラートはページ最上部に出るため、スクロール中は気付けない。
+  // 押しても状態が変わらない理由をカード内でも伝える
+  test('ロックの保存に失敗したらカード内でエラーを伝える', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockRejectedValue(new Error('failed'));
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+    );
+
+    await clickLockToggle();
+
+    const error = container.querySelector('.block-lock-error')!;
+    expect(error).not.toBeNull();
+    expect(error.getAttribute('role')).toBe('alert');
+  });
+
+  // ロックもブロックごと書き戻すため、名前の編集と並行すると
+  // 後から着地した側が相手の変更を打ち消す
+  test('名前を編集している間はロックを切り替えられない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+    );
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.block-title-edit')!.click();
+    });
+    await clickLockToggle();
+
+    expect(updateBlock).not.toHaveBeenCalled();
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('.block-lock-toggle')!
+        .hasAttribute('disabled'),
+    ).toBe(true);
+  });
+});

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -945,8 +945,8 @@ describe('Block 編集のロック', (): void => {
   });
 
   // アイコンの形だけではロック中か一目で分からないという指摘への対応。
-  // カード・バッジ・ボタンの3か所で状態を示す
-  test('ロック中はカードとバッジで状態を示す', async (): Promise<void> => {
+  // 見出し横のバッジとボタンの塗り分けの2点で状態を示す
+  test('ロック中はバッジとボタンで状態を示す', async (): Promise<void> => {
     const updateBlock = jest.fn().mockResolvedValue(undefined);
     await mount(
       [{ url: 'https://example.com/a', title: 'title-a' }],
@@ -954,14 +954,11 @@ describe('Block 編集のロック', (): void => {
       true,
     );
 
+    // バッジは見出しと同じ行に出す
     expect(
-      container
-        .querySelector<HTMLElement>('.block-root-dom')!
-        .getAttribute('data-locked'),
-    ).toBe('true');
-    expect(container.querySelector('.block-locked-badge')!.textContent).toBe(
-      'content_msg_locked_badge',
-    );
+      container.querySelector('.uk-card-title .block-locked-badge')!
+        .textContent,
+    ).toBe('content_msg_locked_badge');
     expect(
       container
         .querySelector<HTMLElement>('.block-lock-toggle')!
@@ -976,12 +973,12 @@ describe('Block 編集のロック', (): void => {
       updateBlock,
     );
 
+    expect(container.querySelector('.block-locked-badge')).toBeNull();
     expect(
       container
-        .querySelector<HTMLElement>('.block-root-dom')!
+        .querySelector<HTMLElement>('.block-lock-toggle')!
         .getAttribute('data-locked'),
     ).toBe('false');
-    expect(container.querySelector('.block-locked-badge')).toBeNull();
   });
 
   // data-uk-iconを持つ要素のclassNameをロックで切り替えると、UIkitが付けた

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -944,6 +944,46 @@ describe('Block 編集のロック', (): void => {
     expect(button.getAttribute('aria-label')).toBe('content_msg_unlock_block');
   });
 
+  // アイコンの形だけではロック中か一目で分からないという指摘への対応。
+  // カード・バッジ・ボタンの3か所で状態を示す
+  test('ロック中はカードとバッジで状態を示す', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+      true,
+    );
+
+    expect(
+      container
+        .querySelector<HTMLElement>('.block-root-dom')!
+        .getAttribute('data-locked'),
+    ).toBe('true');
+    expect(container.querySelector('.block-locked-badge')!.textContent).toBe(
+      'content_msg_locked_badge',
+    );
+    expect(
+      container
+        .querySelector<HTMLElement>('.block-lock-toggle')!
+        .getAttribute('data-locked'),
+    ).toBe('true');
+  });
+
+  test('ロックしていないブロックにはロックの表示を出さない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+    );
+
+    expect(
+      container
+        .querySelector<HTMLElement>('.block-root-dom')!
+        .getAttribute('data-locked'),
+    ).toBe('false');
+    expect(container.querySelector('.block-locked-badge')).toBeNull();
+  });
+
   // data-uk-iconを持つ要素のclassNameをロックで切り替えると、UIkitが付けた
   // uk-iconごとReactに書き換えられ、アイコンの色と行の高さが崩れたまま戻らない
   test('ロック中もアイコンのclassNameは変えず、無効はaria-disabledで表す', async (): Promise<void> => {

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -366,7 +366,15 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   const tabsLocked = editing || titleEditing || lockSaving;
 
   return (
-    <div className="tabs uk-card-default block-root-dom" ref={cardRoot}>
+    // ロック中はカードごと見た目を変える。アイコンの差し替えだけでは
+    // ロックしているか一目で分からず、一覧を眺めても区別が付かない。
+    // 状態はclassNameではなくdata属性で持たせ、UIkitがdata-uk-icon要素へ
+    // 付けたクラスをReactの書き換えで失う経路を作らない
+    <div
+      className="tabs uk-card-default block-root-dom"
+      data-locked={locked}
+      ref={cardRoot}
+    >
       <div className="uk-card-header block-card-header" inert={editing}>
         {/* ロックの切り替えはカードの右上に置く。名前の編集や個々のタブの
             操作より上位の、カード全体に効く操作であるため。
@@ -380,6 +388,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
           type="button"
           ref={lockButton}
           className="uk-link block-lock-toggle"
+          data-locked={locked}
           data-uk-icon={`icon: ${locked ? 'lock' : 'unlock'}; ratio: 0.9`}
           title={chrome.i18n.getMessage(
             locked ? 'content_msg_unlock_block' : 'content_msg_lock_block',
@@ -478,6 +487,16 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
             />
           </h3>
         )}
+        {/* ロック中であることを文字でも出す。アイコンの形だけに頼ると、
+            色覚や視力の差、アイコンの見落としで状態を取り違える */}
+        {locked ? (
+          <p className="uk-margin-remove-top block-locked-badge-row">
+            <span className="block-locked-badge">
+              <span data-uk-icon="icon: lock; ratio: 0.7" />
+              {chrome.i18n.getMessage('content_msg_locked_badge')}
+            </span>
+          </p>
+        ) : null}
         <p className="uk-text-meta uk-margin-remove-top">
           {chrome.i18n.getMessage('content_msg_created_at')}
           <time dateTime={createdAt.toISOString()}>

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -34,6 +34,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   const titleFieldId = useId();
   const titleHintId = useId();
   const [lockError, setLockError] = useState<string | null>(null);
+  // ロックの書き込みが飛行中かどうか。着地するまでpropsのlockedは古いままなので、
+  // その間に始まったタブ操作は自分がロック中であることを知らずに書き戻す
+  const [lockSaving, setLockSaving] = useState(false);
 
   // 誤操作からブロックを守るための状態。ロック中は削除・編集の導線を止め、
   // リンクを開いてもタブを一覧から消さない
@@ -77,13 +80,19 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // タブ配列の差し替えをApp経由でstorageへ反映する。
   // updateBlockはブロックごと書き戻すため、タブだけを変える導線でも
   // タブ以外のフィールドを引き継がないと保存のたびに消える
-  const updateTabs = (tabs: model.Tab[]): Promise<void> =>
-    trackTabWrite(
+  const updateTabs = (tabs: model.Tab[]): Promise<void> => {
+    // storageへ書く唯一の入口でロックを見る。各導線側のガードだけに預けると、
+    // 導線が増えたときに保護が黙って漏れる
+    if (locked) {
+      return Promise.reject(new Error('This block is locked'));
+    }
+    return trackTabWrite(
       props.updateBlock({
         ...block,
         tabs: tabs,
       }),
     );
+  };
 
   // 結果を待たない導線用。失敗はApp側でerrorLogに記録済みなので、
   // ここで受けないとunhandled rejectionになるだけ
@@ -181,28 +190,37 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   /**
    * ロックを切り替えてstorageへ反映する。
    * ロックもブロックごと書き戻すため、名前・タブの書き込みと並行すると
-   * 後から着地した側が相手の変更を打ち消す。飛行中として数え、
-   * 名前を編集している間はボタン側で塞ぐ
+   * 後から着地した側が相手の変更を打ち消す。名前の保存が名前の編集中として
+   * タブ側を止めているのと同じように、着地するまではタブ側の導線も止める
+   * （propsのlockedは着地するまで古いままなので、その隙に始まったタブ操作は
+   * ロックを知らないまま書き戻し、ロックごとブロックを消してしまう）
    */
   const toggleLock = () => {
     // ボタンのdisabledで塞いでいるが、保護をDOMの属性だけに預けない
-    if (tabsWriting || titleEditing || editing) {
+    if (tabsWriting || titleEditing || editing || lockSaving) {
       return;
     }
     setLockError(null);
+    setLockSaving(true);
     trackTabWrite(
       props.updateBlock({
         ...block,
         // ロックしていない状態はキーを持たない形で表す（保存側もそう書く）
         locked: locked ? undefined : true,
       }),
-    ).catch(() => {
-      // App側のアラートはページ最上部に出るためスクロール中は気付けない。
-      // 押しても状態が変わらない理由をカード内でも伝える
-      setLockError(
-        chrome.i18n.getMessage('content_msg_lock_block_save_failed'),
-      );
-    });
+    ).then(
+      () => {
+        setLockSaving(false);
+      },
+      () => {
+        setLockSaving(false);
+        // App側のアラートはページ最上部に出るためスクロール中は気付けない。
+        // 押しても状態が変わらない理由をカード内でも伝える
+        setLockError(
+          chrome.i18n.getMessage('content_msg_lock_block_save_failed'),
+        );
+      },
+    );
   };
 
   // Tab側でもロック中は編集アイコンを無効化しているが、モーダルを開く判断は
@@ -294,6 +312,28 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     titleWasEditing.current = titleDraft != null;
   }, [titleDraft]);
 
+  // ロックボタンは押した瞬間に自分がdisabledになるため、ブラウザがフォーカスを
+  // bodyへ落とす。書き込みが決着したらキーボード操作の現在位置を戻す。
+  // 名前の編集と違い、押した後もボタン自体は同じ場所に残るので、
+  // フォーカスが失われている場合だけ戻せば足りる
+  const lockButton = useRef<HTMLButtonElement>(null);
+  const lockWasSaving = useRef(false);
+  useEffect(() => {
+    if (lockWasSaving.current && !lockSaving) {
+      const active = document.activeElement;
+      if (active == null || active === document.body) {
+        lockButton.current?.focus();
+      }
+    }
+    lockWasSaving.current = lockSaving;
+  }, [lockSaving]);
+
+  // 別の操作が成功してブロックが書き換わったら、前のロック失敗の赤字は
+  // 現在の状態を説明していない。直近の操作が失敗したかのように見えるため消す
+  useEffect(() => {
+    setLockError(null);
+  }, [block]);
+
   const editingTab = editIndex == null ? null : block.tabs[editIndex];
   // モーダルのオーバーレイはクリックしか遮らず、背後のリンクにはTabキーで
   // 到達できてしまう。編集対象をindexで持っているため、開いている間に
@@ -308,37 +348,35 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // ようにして塞ぐ。片方向だけでは「タブ操作の最中に名前を保存する」順序が
   // 残るため、名前→タブ（tabsLocked）とタブ→名前（tabsWriting）の両方を止める。
   // 見出しの入力欄自体は編集中も操作できる必要があるので、
-  // inertはヘッダ全体ではなく操作リンクの行に付ける
-  const tabsLocked = editing || titleEditing;
+  // inertはヘッダ全体ではなく操作リンクの行に付ける。
+  // ロックの書き込み中も同じ理由でタブ側を止める。着地するまでpropsのlockedは
+  // 古いままで、その間に始まったタブ操作はロックを知らないまま書き戻す
+  const tabsLocked = editing || titleEditing || lockSaving;
 
   return (
     <div className="tabs uk-card-default block-root-dom" ref={cardRoot}>
       <div className="uk-card-header block-card-header" inert={editing}>
         {/* ロックの切り替えはカードの右上に置く。名前の編集や個々のタブの
             操作より上位の、カード全体に効く操作であるため。
-            アイコンだけでは何のボタンか分からないので、ホバー用のtitleに
-            加えて支援技術向けにaria-labelとaria-pressedでも状態を伝える */}
+            アイコンだけでは何のボタンか分からないのでホバー用のtitleで補う。
+            支援技術にはaria-pressedだけで状態を伝え、aria-labelは
+            状態で変えない（「解除する」と「押されている」が重なると、
+            解除済みなのかロック中なのか読み手に区別できなくなる） */}
         <button
           type="button"
+          ref={lockButton}
           className="uk-link block-lock-toggle"
           data-uk-icon={`icon: ${locked ? 'lock' : 'unlock'}; ratio: 0.9`}
           title={chrome.i18n.getMessage(
             locked ? 'content_msg_unlock_block' : 'content_msg_lock_block',
           )}
-          aria-label={chrome.i18n.getMessage(
-            locked ? 'content_msg_unlock_block' : 'content_msg_lock_block',
-          )}
+          aria-label={chrome.i18n.getMessage('content_msg_lock_block')}
           aria-pressed={locked}
           // 名前の編集中とタブの書き換え中は、ブロックごとの書き戻しが
           // 打ち消し合うため切り替えさせない
           disabled={tabsWriting || titleEditing}
           onClick={toggleLock}
         />
-        {lockError != null ? (
-          <p className="uk-text-danger block-lock-error" role="alert">
-            {lockError}
-          </p>
-        ) : null}
         {titleEditing ? (
           <form
             className="block-title-form"
@@ -433,7 +471,15 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
             ])}
           </span>
         </p>
-        <div className="uk-grid" inert={titleEditing}>
+        {/* エラーはロックボタンと同じヘッダ内の、見出しの後に出す。
+            見出しより前に差し込むとカードの中身が丸ごとずれて、
+            どのブロックの話か分かりにくくなる */}
+        {lockError != null ? (
+          <p className="uk-text-danger block-lock-error" role="alert">
+            {lockError}
+          </p>
+        ) : null}
+        <div className="uk-grid" inert={titleEditing || lockSaving}>
           <div className="uk-width-auto">
             <span className="all_tab_link uk-link" onClick={openAllTab}>
               {chrome.i18n.getMessage('content_msg_all_tab_open')}
@@ -446,6 +492,13 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
               className={`all_tab_delete ${
                 locked ? 'tab-action-disabled' : 'uk-link'
               }`}
+              role="button"
+              // 淡色になるだけでは押せない理由が伝わらないため補う
+              title={
+                locked
+                  ? chrome.i18n.getMessage('content_msg_locked_action_disabled')
+                  : undefined
+              }
               aria-disabled={locked}
               onClick={locked ? undefined : deleteBlock}
             >

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -200,6 +200,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     if (tabsWriting || titleEditing || editing || lockSaving) {
       return;
     }
+    lockHadFocus.current = document.activeElement === lockButton.current;
     setLockError(null);
     setLockSaving(true);
     trackTabWrite(
@@ -294,6 +295,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // キーボード操作の現在位置が失われる。開いたときのボタンへ戻す
   const cardRoot = useRef<HTMLDivElement>(null);
   const titleEditButton = useRef<HTMLButtonElement>(null);
+  const lockButton = useRef<HTMLButtonElement>(null);
+  // ロックを押した時点でボタンにフォーカスがあったか（キーボード操作か）
+  const lockHadFocus = useRef(false);
   const titleWasEditing = useRef(false);
   useEffect(() => {
     if (titleWasEditing.current && titleDraft == null) {
@@ -316,12 +320,18 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // bodyへ落とす。書き込みが決着したらキーボード操作の現在位置を戻す。
   // 名前の編集と違い、押した後もボタン自体は同じ場所に残るので、
   // フォーカスが失われている場合だけ戻せば足りる
-  const lockButton = useRef<HTMLButtonElement>(null);
   const lockWasSaving = useRef(false);
   useEffect(() => {
     if (lockWasSaving.current && !lockSaving) {
+      // 押した時点でボタンにフォーカスがあったときだけ戻す。
+      // マウスで押してから別の場所をクリックした場合も
+      // フォーカスはbodyに落ちるため、条件をbodyだけにすると
+      // 見ている位置まで勝手にスクロールして戻ってしまう
       const active = document.activeElement;
-      if (active == null || active === document.body) {
+      if (
+        lockHadFocus.current &&
+        (active == null || active === document.body)
+      ) {
         lockButton.current?.focus();
       }
     }
@@ -358,10 +368,12 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
       <div className="uk-card-header block-card-header" inert={editing}>
         {/* ロックの切り替えはカードの右上に置く。名前の編集や個々のタブの
             操作より上位の、カード全体に効く操作であるため。
-            アイコンだけでは何のボタンか分からないのでホバー用のtitleで補う。
-            支援技術にはaria-pressedだけで状態を伝え、aria-labelは
-            状態で変えない（「解除する」と「押されている」が重なると、
-            解除済みなのかロック中なのか読み手に区別できなくなる） */}
+            アイコンだけでは何のボタンか分からないのでtitleで補い、
+            支援技術にも同じ文言をaria-labelで渡す。
+            状態はaria-pressedではなく名前（「ロックする」「解除する」）で
+            伝える。両方を使うと「解除する」と「押されている」が重なって、
+            解除済みなのかロック中なのか読み手に区別できなくなるうえ、
+            見えているツールチップと名前が食い違って音声操作の的も外れる */}
         <button
           type="button"
           ref={lockButton}
@@ -370,8 +382,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
           title={chrome.i18n.getMessage(
             locked ? 'content_msg_unlock_block' : 'content_msg_lock_block',
           )}
-          aria-label={chrome.i18n.getMessage('content_msg_lock_block')}
-          aria-pressed={locked}
+          aria-label={chrome.i18n.getMessage(
+            locked ? 'content_msg_unlock_block' : 'content_msg_lock_block',
+          )}
           // 名前の編集中とタブの書き換え中は、ブロックごとの書き戻しが
           // 打ち消し合うため切り替えさせない
           disabled={tabsWriting || titleEditing}
@@ -489,11 +502,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
             {/* すべてのリンクを閉じるはブロックの削除に等しいため、
                 ロック中は無効化する。開く導線は残す */}
             <span
-              className={`all_tab_delete ${
-                locked ? 'tab-action-disabled' : 'uk-link'
-              }`}
-              role="button"
-              // 淡色になるだけでは押せない理由が伝わらないため補う
+              className="all_tab_delete uk-link"
+              // 淡色になるだけでは押せない理由が伝わらないため補う。
+              // 無効の見た目はaria-disabledを見てCSS側で付ける
               title={
                 locked
                   ? chrome.i18n.getMessage('content_msg_locked_action_disabled')

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -366,15 +366,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   const tabsLocked = editing || titleEditing || lockSaving;
 
   return (
-    // ロック中はカードごと見た目を変える。アイコンの差し替えだけでは
-    // ロックしているか一目で分からず、一覧を眺めても区別が付かない。
-    // 状態はclassNameではなくdata属性で持たせ、UIkitがdata-uk-icon要素へ
-    // 付けたクラスをReactの書き換えで失う経路を作らない
-    <div
-      className="tabs uk-card-default block-root-dom"
-      data-locked={locked}
-      ref={cardRoot}
-    >
+    <div className="tabs uk-card-default block-root-dom" ref={cardRoot}>
       <div className="uk-card-header block-card-header" inert={editing}>
         {/* ロックの切り替えはカードの右上に置く。名前の編集や個々のタブの
             操作より上位の、カード全体に効く操作であるため。
@@ -461,6 +453,14 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
                     block.tabs.length,
                   ])}
             </span>
+            {/* ロック中であることを見出しの隣で文字でも出す。アイコンの形だけに
+                頼ると、色覚や視力の差、アイコンの見落としで状態を取り違える */}
+            {locked ? (
+              <span className="block-locked-badge">
+                <span data-uk-icon="icon: lock; ratio: 0.7" />
+                {chrome.i18n.getMessage('content_msg_locked_badge')}
+              </span>
+            ) : null}
             {/* 名前を付けるのはこの機能の主導線なので、タブ行のアイコン
                 （span）と違ってキーボードから到達できるbutton要素で置く。
                 アイコンだけでは何のボタンか分からないため、ホバー用のtitleに
@@ -487,16 +487,6 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
             />
           </h3>
         )}
-        {/* ロック中であることを文字でも出す。アイコンの形だけに頼ると、
-            色覚や視力の差、アイコンの見落としで状態を取り違える */}
-        {locked ? (
-          <p className="uk-margin-remove-top block-locked-badge-row">
-            <span className="block-locked-badge">
-              <span data-uk-icon="icon: lock; ratio: 0.7" />
-              {chrome.i18n.getMessage('content_msg_locked_badge')}
-            </span>
-          </p>
-        ) : null}
         <p className="uk-text-meta uk-margin-remove-top">
           {chrome.i18n.getMessage('content_msg_created_at')}
           <time dateTime={createdAt.toISOString()}>

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -33,6 +33,11 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   const [titleError, setTitleError] = useState<string | null>(null);
   const titleFieldId = useId();
   const titleHintId = useId();
+  const [lockError, setLockError] = useState<string | null>(null);
+
+  // 誤操作からブロックを守るための状態。ロック中は削除・編集の導線を止め、
+  // リンクを開いてもタブを一覧から消さない
+  const locked = block.locked === true;
 
   // 飛行中のタブ書き換えの本数。propsを見ても決着していない書き込みは
   // 分からないため、名前の編集を始めさせないための判断材料として自前で数える
@@ -88,6 +93,16 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
 
   const openLink = (index: number) => {
     const url = block.tabs[index]!.url;
+    if (locked) {
+      // ロック中は開くだけで一覧から消さない。書き戻しが要らないため
+      // 飛行中としても数えない
+      chromeService.tab
+        .createTabs({ url: url, active: false })
+        .catch((error) => {
+          chromeService.errorLog.set(error).catch(console.error);
+        });
+      return;
+    }
     // タブを開き終わってから書き戻すまでが1つの操作なので、
     // chrome.tabs.createを待つ間も飛行中として数える
     trackTabWrite(
@@ -100,6 +115,11 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   };
 
   const deleteClick = (index: number) => {
+    // 呼び出し元の導線はロック中に塞いであるが、不変条件をUIの分岐だけに
+    // 預けると導線が増えたときに保護が黙って外れる
+    if (locked) {
+      return;
+    }
     updateTabsIgnoringFailure(block.tabs.filter((_, i) => i != index));
   };
 
@@ -119,6 +139,17 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     if (openTabs.length <= 0) {
       // 開くものがないのに書き戻すと、storage.syncの書き込みクォータを
       // 無駄に消費するだけで一覧も変わらない
+      return;
+    }
+    if (locked) {
+      // ロック中は開くだけで一覧から消さない
+      Promise.all(
+        openTabs.map((tab) =>
+          chromeService.tab.createTabs({ url: tab.url, active: false }),
+        ),
+      ).catch((error) => {
+        chromeService.errorLog.set(error).catch(console.error);
+      });
       return;
     }
     // 開き終わってから書き戻すまでを1つの操作としてまとめて数える。
@@ -141,13 +172,52 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   };
 
   const deleteBlock = () => {
+    if (locked) {
+      return;
+    }
     updateTabsIgnoringFailure([]);
+  };
+
+  /**
+   * ロックを切り替えてstorageへ反映する。
+   * ロックもブロックごと書き戻すため、名前・タブの書き込みと並行すると
+   * 後から着地した側が相手の変更を打ち消す。飛行中として数え、
+   * 名前を編集している間はボタン側で塞ぐ
+   */
+  const toggleLock = () => {
+    // ボタンのdisabledで塞いでいるが、保護をDOMの属性だけに預けない
+    if (tabsWriting || titleEditing || editing) {
+      return;
+    }
+    setLockError(null);
+    trackTabWrite(
+      props.updateBlock({
+        ...block,
+        // ロックしていない状態はキーを持たない形で表す（保存側もそう書く）
+        locked: locked ? undefined : true,
+      }),
+    ).catch(() => {
+      // App側のアラートはページ最上部に出るためスクロール中は気付けない。
+      // 押しても状態が変わらない理由をカード内でも伝える
+      setLockError(
+        chrome.i18n.getMessage('content_msg_lock_block_save_failed'),
+      );
+    });
+  };
+
+  // Tab側でもロック中は編集アイコンを無効化しているが、モーダルを開く判断は
+  // ブロックの状態を持つこちらでも確かめる
+  const startTabEdit = (index: number) => {
+    if (locked) {
+      return;
+    }
+    setEditIndex(index);
   };
 
   const startTitleEdit = () => {
     // ボタンのdisabledとヘッダのinertで塞いでいるが、不変条件をDOMの属性だけに
     // 預けると、ボタンの置き場所を変えたときに保護が黙って外れる
-    if (tabsWriting || editing) {
+    if (tabsWriting || editing || locked) {
       return;
     }
     setTitleDraft(block.title ?? '');
@@ -243,7 +313,32 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
 
   return (
     <div className="tabs uk-card-default block-root-dom" ref={cardRoot}>
-      <div className="uk-card-header" inert={editing}>
+      <div className="uk-card-header block-card-header" inert={editing}>
+        {/* ロックの切り替えはカードの右上に置く。名前の編集や個々のタブの
+            操作より上位の、カード全体に効く操作であるため。
+            アイコンだけでは何のボタンか分からないので、ホバー用のtitleに
+            加えて支援技術向けにaria-labelとaria-pressedでも状態を伝える */}
+        <button
+          type="button"
+          className="uk-link block-lock-toggle"
+          data-uk-icon={`icon: ${locked ? 'lock' : 'unlock'}; ratio: 0.9`}
+          title={chrome.i18n.getMessage(
+            locked ? 'content_msg_unlock_block' : 'content_msg_lock_block',
+          )}
+          aria-label={chrome.i18n.getMessage(
+            locked ? 'content_msg_unlock_block' : 'content_msg_lock_block',
+          )}
+          aria-pressed={locked}
+          // 名前の編集中とタブの書き換え中は、ブロックごとの書き戻しが
+          // 打ち消し合うため切り替えさせない
+          disabled={tabsWriting || titleEditing}
+          onClick={toggleLock}
+        />
+        {lockError != null ? (
+          <p className="uk-text-danger block-lock-error" role="alert">
+            {lockError}
+          </p>
+        ) : null}
         {titleEditing ? (
           <form
             className="block-title-form"
@@ -318,8 +413,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
                 'content_msg_edit_block_title',
               )}
               // タブの書き換えが決着するまでは名前を編集させない。
-              // 並行させると後から着地した書き込みが名前を消す
-              disabled={tabsWriting}
+              // 並行させると後から着地した書き込みが名前を消す。
+              // ロック中も名前は編集系の操作として止める
+              disabled={tabsWriting || locked}
               onClick={startTitleEdit}
             />
           </h3>
@@ -344,7 +440,15 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
             </span>
           </div>
           <div className="uk-width-auto">
-            <span className="all_tab_delete uk-link" onClick={deleteBlock}>
+            {/* すべてのリンクを閉じるはブロックの削除に等しいため、
+                ロック中は無効化する。開く導線は残す */}
+            <span
+              className={`all_tab_delete ${
+                locked ? 'tab-action-disabled' : 'uk-link'
+              }`}
+              aria-disabled={locked}
+              onClick={locked ? undefined : deleteBlock}
+            >
               {chrome.i18n.getMessage('content_msg_all_tab_close')}
             </span>
           </div>
@@ -362,6 +466,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
               <BrokenTab
                 key={`${index}-broken`}
                 deleteClick={() => deleteClick(index)}
+                locked={locked}
               />
             ) : (
               // タブ1件の破損でブロックごと落ちると、同じブロックの正常なタブまで
@@ -370,13 +475,19 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
               // 想定していない壊れ方（titleが文字列でない等）への保険
               <ErrorBoundary
                 key={`${index}-${tab.url}`}
-                fallback={<BrokenTab deleteClick={() => deleteClick(index)} />}
+                fallback={
+                  <BrokenTab
+                    deleteClick={() => deleteClick(index)}
+                    locked={locked}
+                  />
+                }
               >
                 <Tab
                   tab={tab}
                   deleteClick={() => deleteClick(index)}
-                  editClick={() => setEditIndex(index)}
+                  editClick={() => startTabEdit(index)}
                   openLinkClick={() => openLink(index)}
+                  locked={locked}
                 />
               </ErrorBoundary>
             ),

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -195,12 +195,15 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
    * （propsのlockedは着地するまで古いままなので、その隙に始まったタブ操作は
    * ロックを知らないまま書き戻し、ロックごとブロックを消してしまう）
    */
-  const toggleLock = () => {
+  const toggleLock = (event: React.MouseEvent) => {
     // ボタンのdisabledで塞いでいるが、保護をDOMの属性だけに預けない
     if (tabsWriting || titleEditing || editing || lockSaving) {
       return;
     }
-    lockHadFocus.current = document.activeElement === lockButton.current;
+    // キーボードから起動したクリックはdetailが0になる。
+    // ブラウザはmousedownでもボタンにフォーカスを移すため、
+    // activeElementを見てもマウス操作と区別できない
+    lockKeyboardActivated.current = event.detail === 0;
     setLockError(null);
     setLockSaving(true);
     trackTabWrite(
@@ -296,8 +299,8 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   const cardRoot = useRef<HTMLDivElement>(null);
   const titleEditButton = useRef<HTMLButtonElement>(null);
   const lockButton = useRef<HTMLButtonElement>(null);
-  // ロックを押した時点でボタンにフォーカスがあったか（キーボード操作か）
-  const lockHadFocus = useRef(false);
+  // ロックの切り替えをキーボードから起動したか
+  const lockKeyboardActivated = useRef(false);
   const titleWasEditing = useRef(false);
   useEffect(() => {
     if (titleWasEditing.current && titleDraft == null) {
@@ -323,13 +326,12 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   const lockWasSaving = useRef(false);
   useEffect(() => {
     if (lockWasSaving.current && !lockSaving) {
-      // 押した時点でボタンにフォーカスがあったときだけ戻す。
-      // マウスで押してから別の場所をクリックした場合も
-      // フォーカスはbodyに落ちるため、条件をbodyだけにすると
-      // 見ている位置まで勝手にスクロールして戻ってしまう
+      // キーボードから押したときだけ戻す。マウスで押してから別の場所を
+      // クリックした場合もフォーカスはbodyに落ちるため、bodyかどうかだけで
+      // 判断すると、見ている位置から勝手にスクロールが戻ってしまう
       const active = document.activeElement;
       if (
-        lockHadFocus.current &&
+        lockKeyboardActivated.current &&
         (active == null || active === document.body)
       ) {
         lockButton.current?.focus();
@@ -459,7 +461,12 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
               ref={titleEditButton}
               className="uk-link uk-margin-small-left block-title-edit"
               data-uk-icon="icon: pencil; ratio: 0.9"
-              title={chrome.i18n.getMessage('content_msg_edit_block_title')}
+              // 押せない理由はタブ行のアイコンと同じ文言で伝える
+              title={
+                locked
+                  ? chrome.i18n.getMessage('content_msg_locked_action_disabled')
+                  : chrome.i18n.getMessage('content_msg_edit_block_title')
+              }
               aria-label={chrome.i18n.getMessage(
                 'content_msg_edit_block_title',
               )}

--- a/src/js/components/brokenBlock.tsx
+++ b/src/js/components/brokenBlock.tsx
@@ -4,6 +4,9 @@ interface BrokenBlockProps {
   indexNum: number;
   // この拡張機能が知らないスキーマ版数のデータか（削除前に警告する）
   unsupported: boolean;
+  // 編集をロックしていたブロックか。描画に失敗するとロックを解除する導線ごと
+  // 失われるため、削除させないのではなく警告して委ねる
+  locked: boolean;
   // storageからの削除とブロック一覧stateの更新はApp側で行う
   deleteBlock: (indexNum: number) => void;
 }
@@ -12,15 +15,21 @@ interface BrokenBlockProps {
 // 一覧から黙って消すとユーザーが手出しできなくなるため、
 // 読み込めなかったことを示して削除導線を提供する
 const BrokenBlock: React.FC<BrokenBlockProps> = (props) => {
+  // 削除前に警告する条件。ロックはユーザーが明示的に付けた保護なので、
+  // 版数が読めないことより優先して伝える
+  const confirmMessageKey = props.locked
+    ? 'content_msg_locked_block_delete_confirm'
+    : props.unsupported
+      ? 'content_msg_unsupported_block_delete_confirm'
+      : null;
+
   const deleteBlock = () => {
     // 新しいバージョンで保存されただけのデータは実データが生きている可能性があり、
     // 削除するとすべての同期端末から消える。ただし削除させないと
     // 「すべてのデータを削除」以外に消す手段がなくなるため、警告して委ねる
     if (
-      props.unsupported &&
-      !window.confirm(
-        chrome.i18n.getMessage('content_msg_unsupported_block_delete_confirm'),
-      )
+      confirmMessageKey != null &&
+      !window.confirm(chrome.i18n.getMessage(confirmMessageKey))
     ) {
       return;
     }

--- a/src/js/components/brokenTab.tsx
+++ b/src/js/components/brokenTab.tsx
@@ -18,6 +18,17 @@ const BrokenTab: React.FC<BrokenTabProps> = (props) => {
           props.locked ? 'tab-action-disabled' : 'uk-link'
         }`}
         data-uk-icon="icon: close; ratio: 0.9"
+        role="button"
+        title={chrome.i18n.getMessage(
+          props.locked
+            ? 'content_msg_locked_action_disabled'
+            : 'content_msg_delete_tab',
+        )}
+        aria-label={chrome.i18n.getMessage(
+          props.locked
+            ? 'content_msg_locked_action_disabled'
+            : 'content_msg_delete_tab',
+        )}
         aria-disabled={props.locked}
         onClick={props.locked ? undefined : props.deleteClick}
       />

--- a/src/js/components/brokenTab.tsx
+++ b/src/js/components/brokenTab.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 interface BrokenTabProps {
   deleteClick: VoidFunction;
+  // ロック中のブロックでは削除もできない。壊れたタブを消すにはロックを解除する
+  locked: boolean;
 }
 
 // 描画できなかったタブ1件の代わりに表示する行。
@@ -12,9 +14,12 @@ const BrokenTab: React.FC<BrokenTabProps> = (props) => {
     <li className="tab-root-dom broken-tab-root-dom">
       <span>{chrome.i18n.getMessage('content_msg_broken_tab')}</span>
       <span
-        className="uk-link tab_close broken_tab_close"
+        className={`tab_close broken_tab_close ${
+          props.locked ? 'tab-action-disabled' : 'uk-link'
+        }`}
         data-uk-icon="icon: close; ratio: 0.9"
-        onClick={props.deleteClick}
+        aria-disabled={props.locked}
+        onClick={props.locked ? undefined : props.deleteClick}
       />
     </li>
   );

--- a/src/js/components/brokenTab.tsx
+++ b/src/js/components/brokenTab.tsx
@@ -24,7 +24,6 @@ const BrokenTab: React.FC<BrokenTabProps> = (props) => {
             ? chrome.i18n.getMessage('content_msg_locked_action_disabled')
             : chrome.i18n.getMessage('content_msg_delete_tab')
         }
-        aria-label={chrome.i18n.getMessage('content_msg_delete_tab')}
         aria-disabled={props.locked}
         onClick={props.locked ? undefined : props.deleteClick}
       />

--- a/src/js/components/brokenTab.tsx
+++ b/src/js/components/brokenTab.tsx
@@ -13,22 +13,18 @@ const BrokenTab: React.FC<BrokenTabProps> = (props) => {
   return (
     <li className="tab-root-dom broken-tab-root-dom">
       <span>{chrome.i18n.getMessage('content_msg_broken_tab')}</span>
+      {/* classNameはロック中も変えない（UIkitが付けるuk-iconごと
+          Reactに書き換えられ、アイコンの見た目が戻らなくなるため）。
+          無効の見た目はaria-disabledを見てCSS側で付ける */}
       <span
-        className={`tab_close broken_tab_close ${
-          props.locked ? 'tab-action-disabled' : 'uk-link'
-        }`}
+        className="uk-link tab_close broken_tab_close"
         data-uk-icon="icon: close; ratio: 0.9"
-        role="button"
-        title={chrome.i18n.getMessage(
+        title={
           props.locked
-            ? 'content_msg_locked_action_disabled'
-            : 'content_msg_delete_tab',
-        )}
-        aria-label={chrome.i18n.getMessage(
-          props.locked
-            ? 'content_msg_locked_action_disabled'
-            : 'content_msg_delete_tab',
-        )}
+            ? chrome.i18n.getMessage('content_msg_locked_action_disabled')
+            : chrome.i18n.getMessage('content_msg_delete_tab')
+        }
+        aria-label={chrome.i18n.getMessage('content_msg_delete_tab')}
         aria-disabled={props.locked}
         onClick={props.locked ? undefined : props.deleteClick}
       />

--- a/src/js/components/main.tsx
+++ b/src/js/components/main.tsx
@@ -22,6 +22,8 @@ const Main: React.FC<MainProps> = (props) => {
               key={entry.indexNum}
               indexNum={entry.indexNum}
               unsupported={entry.unsupported}
+              // 復元できなかったブロックはロックしていたかも分からない
+              locked={false}
               deleteBlock={props.deleteBrokenBlock}
             />
           ) : (
@@ -34,6 +36,9 @@ const Main: React.FC<MainProps> = (props) => {
                 <BrokenBlock
                   indexNum={entry.indexNum}
                   unsupported={false}
+                  // 描画に失敗するとロックを解除する導線ごと失われるため、
+                  // ロックしていたことを削除前の警告として引き継ぐ
+                  locked={entry.locked === true}
                   deleteBlock={props.deleteBrokenBlock}
                 />
               }

--- a/src/js/components/tab.test.tsx
+++ b/src/js/components/tab.test.tsx
@@ -23,6 +23,7 @@ describe('Tab', (): void => {
           deleteClick={jest.fn()}
           editClick={jest.fn()}
           openLinkClick={jest.fn()}
+          locked={false}
         />,
       );
     });
@@ -77,6 +78,7 @@ describe('Tab', (): void => {
           deleteClick={jest.fn()}
           editClick={jest.fn()}
           openLinkClick={openLinkClick}
+          locked={false}
         />,
       );
     });
@@ -99,6 +101,7 @@ describe('Tab', (): void => {
           deleteClick={jest.fn()}
           editClick={editClick}
           openLinkClick={jest.fn()}
+          locked={false}
         />,
       );
     });
@@ -109,6 +112,61 @@ describe('Tab', (): void => {
     });
 
     expect(editClick).toHaveBeenCalledTimes(1);
+  });
+
+  // ロック中のブロックのタブは編集・削除できない(#194)。
+  // アイコンは消さずに無効化するため、押しても何も起きないことを確かめる
+  test('ロック中は編集・削除アイコンを押しても何も起きない', async (): Promise<void> => {
+    const editClick = jest.fn();
+    const deleteClick = jest.fn();
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Tab
+          tab={{ url: 'https://example.com/', title: 'example title' }}
+          deleteClick={deleteClick}
+          editClick={editClick}
+          openLinkClick={jest.fn()}
+          locked={true}
+        />,
+      );
+    });
+
+    const editIcon = container.querySelector<HTMLElement>('.tab_edit')!;
+    const closeIcon = container.querySelector<HTMLElement>('.tab_close')!;
+    await act(async () => {
+      editIcon.click();
+      closeIcon.click();
+    });
+
+    expect(editClick).not.toHaveBeenCalled();
+    expect(deleteClick).not.toHaveBeenCalled();
+    expect(editIcon.getAttribute('aria-disabled')).toBe('true');
+    expect(closeIcon.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  // ロックしても保存したページを見に行けなくなっては困る
+  test('ロック中でもリンクのクリックでopenLinkClickを呼ぶ', async (): Promise<void> => {
+    const openLinkClick = jest.fn();
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Tab
+          tab={{ url: 'https://example.com/', title: 'example title' }}
+          deleteClick={jest.fn()}
+          editClick={jest.fn()}
+          openLinkClick={openLinkClick}
+          locked={true}
+        />,
+      );
+    });
+
+    const link = container.querySelector<HTMLAnchorElement>('a.tab_link')!;
+    await act(async () => {
+      link.click();
+    });
+
+    expect(openLinkClick).toHaveBeenCalledTimes(1);
   });
 
   // urlが空のタブは開けないが、編集で正しいURLに直せる導線は残す必要がある

--- a/src/js/components/tab.tsx
+++ b/src/js/components/tab.tsx
@@ -54,40 +54,35 @@ export const Tab: React.FC<TabProps> = (props) => {
       {/* アイコンだけでは何のボタンか分からないためtitleで補う。
           urlが空のタブもここから修復できるよう、開けるかに関わらず出す。
           ロック中はアイコンを消さずに無効化する。消すと行のレイアウトが
-          変わってロックを解除するまで何ができなくなったのか分からない */}
+          変わってロックを解除するまで何ができなくなったのか分からない。
+          classNameはロック中も変えない。UIkitがdata-uk-iconの初期化時に
+          付けるuk-iconクラスごとReactが書き換えてしまい、
+          data-uk-iconの変化しか見ていないUIkitはもう付け直さないため
+          （アイコンの色と行の高さが崩れたままリロードまで戻らない）。
+          無効の見た目はaria-disabledを見てCSS側で付ける */}
       <span
-        className={`tab_edit ${props.locked ? 'tab-action-disabled' : 'uk-link'}`}
+        className="uk-link tab_edit"
         data-uk-icon="icon: pencil; ratio: 0.9"
-        // 淡色になるだけでは押せない理由が伝わらないため、
-        // ロック中は名前自体を「操作できない」に差し替える
-        role="button"
-        title={chrome.i18n.getMessage(
+        // 押せない理由はtitleで補い、名前（アクセシブル名）は状態で変えない。
+        // 差し替えると編集と削除が同じ名前になり、どちらか区別できなくなる
+        title={
           props.locked
-            ? 'content_msg_locked_action_disabled'
-            : 'content_msg_edit_tab',
-        )}
-        aria-label={chrome.i18n.getMessage(
-          props.locked
-            ? 'content_msg_locked_action_disabled'
-            : 'content_msg_edit_tab',
-        )}
+            ? chrome.i18n.getMessage('content_msg_locked_action_disabled')
+            : chrome.i18n.getMessage('content_msg_edit_tab')
+        }
+        aria-label={chrome.i18n.getMessage('content_msg_edit_tab')}
         aria-disabled={props.locked}
         onClick={props.locked ? undefined : props.editClick}
       />
       <span
-        className={`tab_close ${props.locked ? 'tab-action-disabled' : 'uk-link'}`}
+        className="uk-link tab_close"
         data-uk-icon="icon: close; ratio: 0.9"
-        role="button"
-        title={chrome.i18n.getMessage(
+        title={
           props.locked
-            ? 'content_msg_locked_action_disabled'
-            : 'content_msg_delete_tab',
-        )}
-        aria-label={chrome.i18n.getMessage(
-          props.locked
-            ? 'content_msg_locked_action_disabled'
-            : 'content_msg_delete_tab',
-        )}
+            ? chrome.i18n.getMessage('content_msg_locked_action_disabled')
+            : chrome.i18n.getMessage('content_msg_delete_tab')
+        }
+        aria-label={chrome.i18n.getMessage('content_msg_delete_tab')}
         aria-disabled={props.locked}
         onClick={props.locked ? undefined : props.deleteClick}
       />

--- a/src/js/components/tab.tsx
+++ b/src/js/components/tab.tsx
@@ -63,14 +63,15 @@ export const Tab: React.FC<TabProps> = (props) => {
       <span
         className="uk-link tab_edit"
         data-uk-icon="icon: pencil; ratio: 0.9"
-        // 押せない理由はtitleで補い、名前（アクセシブル名）は状態で変えない。
-        // 差し替えると編集と削除が同じ名前になり、どちらか区別できなくなる
+        // 押せない理由はtitleで補う。名前は状態で変えない（差し替えると
+        // 編集と削除が同じ名前になり、どちらか区別できなくなる）。
+        // ロールを持たないspanにaria-labelは効かないため付けない。
+        // aria-disabledは無効の見た目をCSSから当てるための目印
         title={
           props.locked
             ? chrome.i18n.getMessage('content_msg_locked_action_disabled')
             : chrome.i18n.getMessage('content_msg_edit_tab')
         }
-        aria-label={chrome.i18n.getMessage('content_msg_edit_tab')}
         aria-disabled={props.locked}
         onClick={props.locked ? undefined : props.editClick}
       />
@@ -82,7 +83,6 @@ export const Tab: React.FC<TabProps> = (props) => {
             ? chrome.i18n.getMessage('content_msg_locked_action_disabled')
             : chrome.i18n.getMessage('content_msg_delete_tab')
         }
-        aria-label={chrome.i18n.getMessage('content_msg_delete_tab')}
         aria-disabled={props.locked}
         onClick={props.locked ? undefined : props.deleteClick}
       />

--- a/src/js/components/tab.tsx
+++ b/src/js/components/tab.tsx
@@ -58,13 +58,36 @@ export const Tab: React.FC<TabProps> = (props) => {
       <span
         className={`tab_edit ${props.locked ? 'tab-action-disabled' : 'uk-link'}`}
         data-uk-icon="icon: pencil; ratio: 0.9"
-        title={chrome.i18n.getMessage('content_msg_edit_tab')}
+        // 淡色になるだけでは押せない理由が伝わらないため、
+        // ロック中は名前自体を「操作できない」に差し替える
+        role="button"
+        title={chrome.i18n.getMessage(
+          props.locked
+            ? 'content_msg_locked_action_disabled'
+            : 'content_msg_edit_tab',
+        )}
+        aria-label={chrome.i18n.getMessage(
+          props.locked
+            ? 'content_msg_locked_action_disabled'
+            : 'content_msg_edit_tab',
+        )}
         aria-disabled={props.locked}
         onClick={props.locked ? undefined : props.editClick}
       />
       <span
         className={`tab_close ${props.locked ? 'tab-action-disabled' : 'uk-link'}`}
         data-uk-icon="icon: close; ratio: 0.9"
+        role="button"
+        title={chrome.i18n.getMessage(
+          props.locked
+            ? 'content_msg_locked_action_disabled'
+            : 'content_msg_delete_tab',
+        )}
+        aria-label={chrome.i18n.getMessage(
+          props.locked
+            ? 'content_msg_locked_action_disabled'
+            : 'content_msg_delete_tab',
+        )}
         aria-disabled={props.locked}
         onClick={props.locked ? undefined : props.deleteClick}
       />

--- a/src/js/components/tab.tsx
+++ b/src/js/components/tab.tsx
@@ -7,6 +7,9 @@ interface TabProps {
   deleteClick: VoidFunction;
   editClick: VoidFunction;
   openLinkClick: VoidFunction;
+  // ロック中のブロックのタブは編集・削除できない。
+  // リンクを開く導線は残す（開いても一覧から消さないのはBlock側の判断）
+  locked: boolean;
 }
 
 /**
@@ -49,17 +52,21 @@ export const Tab: React.FC<TabProps> = (props) => {
         </span>
       )}
       {/* アイコンだけでは何のボタンか分からないためtitleで補う。
-          urlが空のタブもここから修復できるよう、開けるかに関わらず出す */}
+          urlが空のタブもここから修復できるよう、開けるかに関わらず出す。
+          ロック中はアイコンを消さずに無効化する。消すと行のレイアウトが
+          変わってロックを解除するまで何ができなくなったのか分からない */}
       <span
-        className="uk-link tab_edit"
+        className={`tab_edit ${props.locked ? 'tab-action-disabled' : 'uk-link'}`}
         data-uk-icon="icon: pencil; ratio: 0.9"
         title={chrome.i18n.getMessage('content_msg_edit_tab')}
-        onClick={props.editClick}
+        aria-disabled={props.locked}
+        onClick={props.locked ? undefined : props.editClick}
       />
       <span
-        className="uk-link tab_close"
+        className={`tab_close ${props.locked ? 'tab-action-disabled' : 'uk-link'}`}
         data-uk-icon="icon: close; ratio: 0.9"
-        onClick={props.deleteClick}
+        aria-disabled={props.locked}
+        onClick={props.locked ? undefined : props.deleteClick}
       />
     </li>
   );

--- a/src/js/types/interface.d.ts
+++ b/src/js/types/interface.d.ts
@@ -12,6 +12,13 @@ export namespace model {
      * 名前を消したブロックはundefinedになり、一覧ではタブ数を表示する
      */
     title?: string;
+    /**
+     * ブロックの編集をロックしているか。
+     * ロック中は削除・編集の導線を止め、リンクを開いてもタブを消さない。
+     * ロックしていないブロック（旧スキーマで保存されたデータを含む）は
+     * undefinedになる
+     */
+    locked?: boolean;
   }
 
   interface Tab {


### PR DESCRIPTION
保存したブロック単位で編集をロックできるようにします。

Closes #194

## 挙動

- ロック/解除ボタンはブロックカードの**右上**（UIkit の `lock` / `unlock` アイコン、`aria-pressed` で状態を通知）
- ロック中に止めるもの
  - ブロックの削除（「すべてのリンクを閉じる」）
  - 名前の編集
  - タブの編集・削除（壊れたタブの削除を含む）
- ロック中も動くもの
  - リンクを開く／「すべてのリンクを開く」— ただし**開いてもタブを一覧から消さない**（issue のコメント通り）

## 保存形式

- `model.Block` に `locked?: boolean` を追加し、**ロック中のブロックだけ `"locked": true` を書く**
- `title`（#195）と同じく**スキーマ版数は据え置き**。上げると旧バージョンが sync 経由で降りてきたブロックを `UnsupportedVersionError` で一切表示できなくなるため
  - 代償として、`locked` を知らない旧バージョンが同じブロックを書き戻すとロックは失われる。`title` と同根の既存の制約として許容し、コードにコメントを残しています
- インポート JSON には型の検証がないため、読み込み時は**真偽値の `true` だけ**をロックとみなす（`"false"` のような文字列を truthy で拾わない）

## 書き込み競合

ロックもブロックごと書き戻すため、名前・タブの書き込みと並行すると後から着地した側が相手の変更を打ち消します。既存の `trackTabWrite` で飛行中として数え、名前の編集中・タブの書き換え中はロックボタンを disabled にしています。

## 既知の制約（スコープ外）

- サイドバーの「すべてのデータを削除する」はロック中のブロックも削除します（ブロック単位ではなく全消しの導線で、確認ダイアログと警告文が別途あるため）
- **ロックは同一ページ内の誤操作を防ぐもので、データの改変を保証する仕組みではありません。** 一覧は `storage.onChanged` を購読していないため、tabs.html を複数枚開いていると古いスナップショットを持つページからロックを無視した書き戻しができます。`title`（#195）が消えるのと同根の既存課題で、購読の導入は編集中の衝突処理まで巻き込む独立した設計変更になるため、この PR では持ち越しています
- ロックを知らない旧バージョンが同じブロックを書き戻すとロックは失われます（`title` と同じ扱い）
- 描画に失敗したロック済みブロックはロックを解除する導線ごと失われるため、削除だけは確認ダイアログ付きで許可しています

## 検証

- `npm run format:check` / `npm run lint` / `npm test`（168 件）すべて green
- `npx webpack --config webpack.dev.js` でビルド成功
- **未実施**: 拡張機能を読み込んでの手動確認（ロックアイコンの見た目・右上の配置・淡色表示）
