### PR TITLE
データが直ったらErrorBoundaryの表示をやり直す

### DIFF
--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -1522,6 +1522,136 @@ describe('App', (): void => {
       consoleErrorSpy.mockRestore();
     }
   });
+  // 境界は位置で固定されており、同じindexNumのブロックが差し替わっても
+  // 再マウントされない。読み直しで直ったのに削除しか導線がないカードが
+  // 残り続けると、直っているデータを消す方向へ誘導してしまう(#256)
+  test('読み直しでデータが直ったブロックはカードから一覧に戻る', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([
+      {
+        indexNum: 0,
+        // createdAtが不正なDateだとblock.tsxのtoISOString()がRangeErrorを投げる
+        createdAt: new Date('invalid'),
+        tabs: [{ url: 'https://example.com/broken', title: 'title-broken' }],
+      },
+      {
+        indexNum: 1,
+        createdAt: new Date('2021-01-02T03:04:05.678Z'),
+        tabs: [{ url: 'https://example.com/valid', title: 'title-valid' }],
+      },
+    ]);
+    // Reactが境界で捕捉した例外をconsole.errorへ出力するため抑止する
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    try {
+      await mount();
+      expect(container.textContent).toContain('content_msg_broken_block');
+
+      // 他端末が壊れたブロックを正常なデータに書き換えた
+      getAllBlockSpy.mockResolvedValue([
+        {
+          indexNum: 0,
+          createdAt: new Date('2021-01-02T03:04:05.678Z'),
+          tabs: [{ url: 'https://example.com/broken', title: 'title-fixed' }],
+        },
+        {
+          indexNum: 1,
+          createdAt: new Date('2021-01-02T03:04:05.678Z'),
+          tabs: [{ url: 'https://example.com/valid', title: 'title-valid' }],
+        },
+      ]);
+      await act(async () => {
+        notifySync({ td_0: { newValue: 'fixed' } });
+      });
+
+      // リロードを待たずにタブの一覧として表示される
+      expect(container.textContent).not.toContain('content_msg_broken_block');
+      expect(container.textContent).toContain('title-fixed');
+      expect(container.textContent).toContain('title-valid');
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  test('読み直しても直っていないブロックはカードのまま残る', async (): Promise<void> => {
+    const brokenBlocks = () => [
+      {
+        indexNum: 0,
+        createdAt: new Date('invalid'),
+        tabs: [{ url: 'https://example.com/broken', title: 'title-broken' }],
+      },
+      {
+        indexNum: 1,
+        createdAt: new Date('2021-01-02T03:04:05.678Z'),
+        tabs: [{ url: 'https://example.com/valid', title: 'title-valid' }],
+      },
+    ];
+    getAllBlockSpy.mockResolvedValue(brokenBlocks());
+    // Reactが境界で捕捉した例外をconsole.errorへ出力するため抑止する
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    try {
+      await mount();
+
+      // 読み直しても壊れ方は同じ（再試行してまた落ちる）
+      getAllBlockSpy.mockResolvedValue(brokenBlocks());
+      await act(async () => {
+        notifySync({ td_1: { newValue: 'touched' } });
+      });
+
+      expect(container.textContent).toContain('content_msg_broken_block');
+      expect(container.textContent).not.toContain('title-broken');
+      expect(container.textContent).toContain('title-valid');
+      // 再試行を繰り返して一覧が空になったりしない
+      expect(container.textContent).not.toContain('content_msg_not_tab');
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  // Mainを囲む境界にはfallbackが無く、一度落ちると一覧そのものが失われる。
+  // ここが復帰しないと読み直しても一覧が戻らない(#256)
+  test('Main全体が落ちても読み直しで一覧が戻る', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([]);
+    // 「保存済みタブなし」の表示でMain自体がレンダリング時に落ちる状況を作る
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome.i18n.getMessage = (key: string): string => {
+      if (key === 'content_msg_not_tab') {
+        throw new Error('i18n boom');
+      }
+      return key;
+    };
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    try {
+      await mount();
+
+      // 一覧は失われるが、ヘッダーとサイドバーは残る
+      expect(container.textContent).not.toContain('content_msg_not_tab');
+      expect(container.textContent).toContain('content_msg_menu');
+
+      getAllBlockSpy.mockResolvedValue([
+        {
+          indexNum: 0,
+          createdAt: new Date('2021-01-02T03:04:05.678Z'),
+          tabs: [{ url: 'https://example.com/a', title: 'title-a' }],
+        },
+      ]);
+      await act(async () => {
+        notifySync({ t_len: { newValue: '1' } });
+      });
+
+      expect(container.textContent).toContain('title-a');
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   // 一覧はマウント時のstorageの内容を持ち続けるため、他のtabsページや
   // 他の端末(sync)での変更に追随できないと、古い一覧からの書き戻しで
   // 相手の変更を消してしまう

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -1610,8 +1610,11 @@ describe('App', (): void => {
 
       expect(container.textContent).toContain('content_msg_broken_block');
       expect(container.textContent).toContain('title-valid');
-      // 読み直し2回で試行は3回。リセットと例外を繰り返して回り続けない
-      expect(consoleErrorSpy.mock.calls.length).toBe(perAttempt * 3);
+      // 読み直し2回で試行は3回まで。リセットと例外を繰り返して回り続けない
+      // （Reactが出すログを間接的に数えているため上限で見る）
+      expect(consoleErrorSpy.mock.calls.length).toBeLessThanOrEqual(
+        perAttempt * 3,
+      );
     } finally {
       consoleErrorSpy.mockRestore();
     }

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -1595,18 +1595,23 @@ describe('App', (): void => {
 
     try {
       await mount();
+      // 1回のレンダリング試行でReactがconsole.errorへ出す回数
+      const perAttempt = consoleErrorSpy.mock.calls.length;
 
-      // 読み直しても壊れ方は同じ（再試行してまた落ちる）
-      getAllBlockSpy.mockResolvedValue(brokenBlocks());
-      await act(async () => {
-        notifySync({ td_1: { newValue: 'touched' } });
-      });
+      // 読み直しても壊れ方は同じ（再試行してまた落ちる）。
+      // 一覧の読み直しは内容が同じでもBlockEntryを作り直すため、
+      // resetKeyは毎回変わり、読み直しごとに1回だけ再試行される
+      for (const key of ['td_1', 't_len']) {
+        getAllBlockSpy.mockResolvedValue(brokenBlocks());
+        await act(async () => {
+          notifySync({ [key]: { newValue: 'touched' } });
+        });
+      }
 
       expect(container.textContent).toContain('content_msg_broken_block');
-      expect(container.textContent).not.toContain('title-broken');
       expect(container.textContent).toContain('title-valid');
-      // 再試行を繰り返して一覧が空になったりしない
-      expect(container.textContent).not.toContain('content_msg_not_tab');
+      // 読み直し2回で試行は3回。リセットと例外を繰り返して回り続けない
+      expect(consoleErrorSpy.mock.calls.length).toBe(perAttempt * 3);
     } finally {
       consoleErrorSpy.mockRestore();
     }

--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -173,7 +173,9 @@ const App: React.FC = () => {
           {/* Mainのレンダリング時例外でHeader/ErrorDisplay/SideBarまで
               アンマウントされないよう境界で隔離する（旧・独立ルート構成が
               持っていたフォールトアイソレーションの維持） */}
-          <ErrorBoundary>
+          {/* 一覧が読み直されたら表示をやり直す。この境界にfallbackは無く、
+              一度落ちると一覧そのものが失われるため復帰の必要が最も大きい */}
+          <ErrorBoundary resetKey={sortedBlocks}>
             {/* ロード中に「保存済みタブなし」を誤表示しないよう
                 ロード完了までMainをマウントしない */}
             {sortedBlocks != null ? (

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -1670,17 +1670,23 @@ describe('Block 落ちたタブの表示が読み直しで戻るか', (): void =
     expect(container.textContent).toContain('title-a');
   });
 
-  test('直っていないタブは読み直してもカードのまま', async (): Promise<void> => {
+  test('直っていないタブは読み直しごとに1回だけ再試行してカードのまま', async (): Promise<void> => {
     const broken = { url: 'https://example.com/a', title: brokenTitle };
     await render([broken, { url: 'https://example.com/b', title: 'title-b' }]);
+    // 1回のレンダリング試行でReactがconsole.errorへ出す回数
+    const perAttempt = consoleErrorSpy.mock.calls.length;
 
     // 壊れたまま読み直された（別のオブジェクトだが中身は同じ）
-    await render([
-      { ...broken },
-      { url: 'https://example.com/b', title: 'title-b' },
-    ]);
+    for (let i = 0; i < 2; i += 1) {
+      await render([
+        { ...broken },
+        { url: 'https://example.com/b', title: 'title-b' },
+      ]);
+    }
 
     expect(container.querySelectorAll('.broken_tab_close')).toHaveLength(1);
     expect(container.textContent).toContain('title-b');
+    // 読み直し2回で試行は3回。カードのままでも再試行が二重に走らない
+    expect(consoleErrorSpy.mock.calls.length).toBe(perAttempt * 3);
   });
 });

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -1604,3 +1604,83 @@ describe('Block 編集中に外からタブが変わったとき', (): void => {
     ).toBe(true);
   });
 });
+
+// タブ単位の境界のkeyはurlを含むため、urlが変わったタブは再マウントされる。
+// 同じurlのままtitleだけ直ったケースはkeyでは拾えない(#256)
+describe('Block 落ちたタブの表示が読み直しで戻るか', (): void => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  const render = async (tabs: model.Tab[]): Promise<void> => {
+    await act(async () => {
+      root.render(
+        <Block
+          block={{
+            indexNum: 0,
+            createdAt: new Date('2021-01-02T03:04:05.678Z'),
+            tabs: tabs,
+          }}
+          updateBlock={jest.fn().mockResolvedValue(undefined)}
+        />,
+      );
+    });
+  };
+
+  // Reactの子として渡せない値。Tabのレンダリングが例外になる
+  const brokenTitle = {} as unknown as string;
+
+  beforeEach((): void => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      i18n: {
+        getMessage: (key: string): string => key,
+      },
+    };
+    // Reactが境界で捕捉した例外をconsole.errorへ出力するため抑止する
+    consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach((): void => {
+    act(() => root.unmount());
+    container.remove();
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('urlが同じままtitleだけ直ったタブも表示が戻る', async (): Promise<void> => {
+    await render([
+      { url: 'https://example.com/a', title: brokenTitle },
+      { url: 'https://example.com/b', title: 'title-b' },
+    ]);
+
+    expect(container.querySelectorAll('.broken_tab_close')).toHaveLength(1);
+
+    // 他端末でtitleだけが直った（urlは変わらないのでkeyは同じ）
+    await render([
+      { url: 'https://example.com/a', title: 'title-a' },
+      { url: 'https://example.com/b', title: 'title-b' },
+    ]);
+
+    expect(container.querySelectorAll('.broken_tab_close')).toHaveLength(0);
+    expect(container.textContent).toContain('title-a');
+  });
+
+  test('直っていないタブは読み直してもカードのまま', async (): Promise<void> => {
+    const broken = { url: 'https://example.com/a', title: brokenTitle };
+    await render([broken, { url: 'https://example.com/b', title: 'title-b' }]);
+
+    // 壊れたまま読み直された（別のオブジェクトだが中身は同じ）
+    await render([
+      { ...broken },
+      { url: 'https://example.com/b', title: 'title-b' },
+    ]);
+
+    expect(container.querySelectorAll('.broken_tab_close')).toHaveLength(1);
+    expect(container.textContent).toContain('title-b');
+  });
+});

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -1686,7 +1686,10 @@ describe('Block 落ちたタブの表示が読み直しで戻るか', (): void =
 
     expect(container.querySelectorAll('.broken_tab_close')).toHaveLength(1);
     expect(container.textContent).toContain('title-b');
-    // 読み直し2回で試行は3回。カードのままでも再試行が二重に走らない
-    expect(consoleErrorSpy.mock.calls.length).toBe(perAttempt * 3);
+    // 読み直し2回で試行は3回まで。カードのままでも再試行が二重に走らない
+    // （Reactが出すログを間接的に数えているため上限で見る）
+    expect(consoleErrorSpy.mock.calls.length).toBeLessThanOrEqual(
+      perAttempt * 3,
+    );
   });
 });

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -731,6 +731,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
               // 想定していない壊れ方（titleが文字列でない等）への保険
               <ErrorBoundary
                 key={`${index}-${tab.url}`}
+                // urlが変わればkeyごと変わって再マウントされるが、
+                // 同じurlのままtitleだけ直ったケースはkeyでは拾えない
+                resetKey={tab}
                 fallback={
                   <BrokenTab
                     deleteClick={() => deleteClick(index)}

--- a/src/js/components/errorBoundary.test.tsx
+++ b/src/js/components/errorBoundary.test.tsx
@@ -43,6 +43,14 @@ describe('ErrorBoundary', (): void => {
 
   beforeEach((): void => {
     renderCount = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      storage: { local: { set: jest.fn().mockResolvedValue(undefined) } },
+      action: {
+        setBadgeText: jest.fn(),
+        setBadgeBackgroundColor: jest.fn(),
+      },
+    };
     container = document.createElement('div');
     document.body.appendChild(container);
     act(() => {
@@ -190,6 +198,42 @@ describe('ErrorBoundary', (): void => {
       await render({ throws: true, resetKey: 'v3' });
 
       expect(errorLogSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      errorLogSpy.mockRestore();
+    }
+  });
+
+  // 抑制は「落ちている間の同じ壊れ方」に限る。復帰後の障害まで黙ると、
+  // 一覧が失われたのに手掛かりが何も出ない状態になる
+  test('復帰したあとに同じメッセージで落ちたら改めて記録する', async (): Promise<void> => {
+    const errorLogSpy = jest
+      .spyOn(chromeService.errorLog, 'set')
+      .mockResolvedValue(undefined);
+
+    try {
+      await render({ throws: true, resetKey: 'v1' });
+      await render({ throws: false, resetKey: 'v2' });
+      await render({ throws: true, resetKey: 'v3' });
+
+      expect(errorLogSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      errorLogSpy.mockRestore();
+    }
+  });
+
+  // 記録できていなければ通知は出ていないので、抑制の対象にしない
+  test('errorLogへの記録に失敗したら次の試行でやり直す', async (): Promise<void> => {
+    const errorLogSpy = jest
+      .spyOn(chromeService.errorLog, 'set')
+      .mockRejectedValue(new Error('storage full'));
+
+    try {
+      await render({ throws: true, resetKey: 'v1' });
+      // 記録の失敗はPromiseの決着を待つ必要がある
+      await act(async () => {});
+      await render({ throws: true, resetKey: 'v2' });
+
+      expect(errorLogSpy).toHaveBeenCalledTimes(2);
     } finally {
       errorLogSpy.mockRestore();
     }

--- a/src/js/components/errorBoundary.test.tsx
+++ b/src/js/components/errorBoundary.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { ErrorBoundary } from './errorBoundary';
+import { chromeService } from '../chromeService';
+
+// テスティングライブラリを介さず素のactを使うため必要
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('ErrorBoundary', (): void => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let consoleErrorSpy: jest.SpyInstance;
+  // 子が何回レンダリングを試みたか。落ちたままリセットを繰り返して
+  // レンダリングが振動しないことを見るために数える
+  let renderCount: number;
+
+  // throwsがtrueの間はレンダリングで例外を投げる子
+  const Child: React.FC<{ throws: boolean }> = (props) => {
+    renderCount += 1;
+    if (props.throws) {
+      throw new Error('boom');
+    }
+    return <span>child</span>;
+  };
+
+  const render = (props: {
+    throws: boolean;
+    resetKey?: unknown;
+    fallback?: React.ReactNode;
+  }): Promise<void> =>
+    act(async () => {
+      root.render(
+        <ErrorBoundary resetKey={props.resetKey} fallback={props.fallback}>
+          <Child throws={props.throws} />
+        </ErrorBoundary>,
+      );
+    });
+
+  beforeEach((): void => {
+    renderCount = 0;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    act(() => {
+      root = createRoot(container);
+    });
+    // Reactが境界で捕捉した例外をconsole.errorへ出力するため抑止する
+    consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach((): void => {
+    act(() => root.unmount());
+    container.remove();
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('捕捉後にresetKeyが変わればレンダリングをやり直す', async (): Promise<void> => {
+    await render({
+      throws: true,
+      resetKey: 'v1',
+      fallback: <span>broken</span>,
+    });
+    expect(container.textContent).toBe('broken');
+
+    // 落ちた原因のデータが差し替わった状況
+    await render({
+      throws: false,
+      resetKey: 'v2',
+      fallback: <span>broken</span>,
+    });
+
+    expect(container.textContent).toBe('child');
+  });
+
+  test('resetKeyが変わらなければデータが直ってもfallbackのまま', async (): Promise<void> => {
+    await render({
+      throws: true,
+      resetKey: 'v1',
+      fallback: <span>broken</span>,
+    });
+    // resetKeyは据え置き。読み直しても中身が変わらなかったブロックに相当する
+    await render({
+      throws: false,
+      resetKey: 'v1',
+      fallback: <span>broken</span>,
+    });
+
+    expect(container.textContent).toBe('broken');
+  });
+
+  test('resetKeyを渡さない呼び出しは従来どおりfallbackに固定される', async (): Promise<void> => {
+    await render({ throws: true, fallback: <span>broken</span> });
+    await render({ throws: false, fallback: <span>broken</span> });
+
+    expect(container.textContent).toBe('broken');
+  });
+
+  test('直っていないデータで再試行してもfallbackに収束する', async (): Promise<void> => {
+    await render({
+      throws: true,
+      resetKey: 'v1',
+      fallback: <span>broken</span>,
+    });
+    const rendersForFirstAttempt = renderCount;
+
+    // 壊れたまま読み直された状況。再試行してまた落ちる
+    await render({
+      throws: true,
+      resetKey: 'v2',
+      fallback: <span>broken</span>,
+    });
+    expect(container.textContent).toBe('broken');
+    // 増えるのは再試行1回分だけ。リセットと例外を繰り返して回り続けない
+    expect(renderCount).toBe(rendersForFirstAttempt * 2);
+
+    // 同じresetKeyで再レンダリングされても、もう再試行しない
+    await render({
+      throws: true,
+      resetKey: 'v2',
+      fallback: <span>broken</span>,
+    });
+    expect(renderCount).toBe(rendersForFirstAttempt * 2);
+  });
+
+  test('落ちていなければresetKeyが変わっても子を作り直さない', async (): Promise<void> => {
+    await render({ throws: false, resetKey: 'v1' });
+    const rendersBefore = renderCount;
+
+    await render({ throws: false, resetKey: 'v2' });
+
+    // resetKeyの変更で親が再レンダリングされる1回だけ
+    expect(renderCount).toBe(rendersBefore + 1);
+    expect(container.textContent).toBe('child');
+  });
+
+  test('fallbackを渡さない境界は捕捉した例外をerrorLogへ記録する', async (): Promise<void> => {
+    const errorLogSpy = jest
+      .spyOn(chromeService.errorLog, 'set')
+      .mockResolvedValue(undefined);
+
+    try {
+      await render({ throws: true, resetKey: 'v1' });
+      expect(container.textContent).toBe('');
+      expect(errorLogSpy).toHaveBeenCalledTimes(1);
+
+      // 読み直しで直れば表示が戻る（この境界が落ちると一覧全体が失われる）
+      await render({ throws: false, resetKey: 'v2' });
+      expect(container.textContent).toBe('child');
+    } finally {
+      errorLogSpy.mockRestore();
+    }
+  });
+});

--- a/src/js/components/errorBoundary.test.tsx
+++ b/src/js/components/errorBoundary.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { act } from 'react';
+import { act, useLayoutEffect, useRef } from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { ErrorBoundary } from './errorBoundary';
 import { chromeService } from '../chromeService';
@@ -134,9 +134,65 @@ describe('ErrorBoundary', (): void => {
 
     await render({ throws: false, resetKey: 'v2' });
 
-    // resetKeyの変更で親が再レンダリングされる1回だけ
+    // resetKeyの変更で親が再レンダリングされる1回だけ。
+    // StrictModeを使わない前提の回数（使うと二重に呼ばれる）
     expect(renderCount).toBe(rendersBefore + 1);
     expect(container.textContent).toBe('child');
+  });
+
+  // 親のuseLayoutEffectは子のコミット後のDOMを測る。リセットを別のコミットに
+  // 分けると、親が測るのはfallbackを描いた時点のDOMになり、直った後の
+  // レイアウトを見逃す（main.tsxの並び替え演出が誤った位置から動かす）
+  test('復帰は親のレイアウト測定と同じコミットで終わる', async (): Promise<void> => {
+    const observed: string[] = [];
+    const Parent: React.FC<{ throws: boolean; resetKey: string }> = (props) => {
+      const ref = useRef<HTMLDivElement>(null);
+      useLayoutEffect(() => {
+        observed.push(ref.current!.textContent ?? '');
+      });
+      return (
+        <div ref={ref}>
+          <ErrorBoundary
+            resetKey={props.resetKey}
+            fallback={<span>broken</span>}
+          >
+            <Child throws={props.throws} />
+          </ErrorBoundary>
+        </div>
+      );
+    };
+
+    await act(async () => {
+      root.render(<Parent throws={true} resetKey="v1" />);
+    });
+    await act(async () => {
+      root.render(<Parent throws={false} resetKey="v2" />);
+    });
+
+    // 直った後のDOMを親が測れている（最後の測定がfallbackで止まらない）
+    expect(container.textContent).toBe('child');
+    expect(observed[observed.length - 1]).toBe('child');
+  });
+
+  // 記録するとバッジとアラートが出る。同じ壊れ方で再試行するたびに
+  // 記録し直すと、利用者が閉じたアラートが読み直しごとに復活する
+  test('同じ壊れ方で再試行してもerrorLogへは記録し直さない', async (): Promise<void> => {
+    const errorLogSpy = jest
+      .spyOn(chromeService.errorLog, 'set')
+      .mockResolvedValue(undefined);
+
+    try {
+      await render({ throws: true, resetKey: 'v1' });
+      expect(errorLogSpy).toHaveBeenCalledTimes(1);
+
+      // 壊れたまま読み直された（再試行してまた同じ例外で落ちる）
+      await render({ throws: true, resetKey: 'v2' });
+      await render({ throws: true, resetKey: 'v3' });
+
+      expect(errorLogSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      errorLogSpy.mockRestore();
+    }
   });
 
   test('fallbackを渡さない境界は捕捉した例外をerrorLogへ記録する', async (): Promise<void> => {

--- a/src/js/components/errorBoundary.tsx
+++ b/src/js/components/errorBoundary.tsx
@@ -8,7 +8,9 @@ interface ErrorBoundaryProps {
   // 表示をやり直す契機。この値が変わったら子のレンダリングを再試行する。
   // 一覧の読み直し(#249)は内容が同じでもBlockEntryを作り直すため、
   // 呼び出し側が落ちた原因のデータを渡すと「読み直しごとに1回再試行する」
-  // 意味になる。直っていなければ同じレンダーの中でfallbackへ戻る
+  // 意味になる。直っていなければ同じレンダーの中でfallbackへ戻る。
+  // レンダリングごとに作り直す値（インラインのオブジェクトリテラル等）を
+  // 渡してはいけない。落ちたまま再試行を繰り返して収束しなくなる
   resetKey?: unknown;
 }
 
@@ -30,14 +32,17 @@ export class ErrorBoundary extends React.Component<
   ErrorBoundaryProps,
   ErrorBoundaryState
 > {
+  // getDerivedStateFromPropsは初回レンダリングの前にも走るためresetKeyは
+  // そこで揃うが、リセットの判定がprops基準であることを型と初期値でも示す
   state: ErrorBoundaryState = {
     hasError: false,
     resetKey: this.props.resetKey,
   };
 
-  // 直近にerrorLogへ記録したメッセージ。同じ壊れ方で再試行するたびに
-  // 記録し直すと、利用者が閉じたアラートとバッジが読み直しごとに復活する
-  private loggedMessage: string | null = null;
+  // 落ちている間にerrorLogへ記録したメッセージ。同じ壊れ方で再試行する
+  // たびに記録し直すと、利用者が閉じたアラートとバッジが読み直しごとに
+  // 復活する。復帰したら忘れる（同じメッセージでも別の機会の障害は通知する）
+  private loggedMessages = new Set<string>();
 
   static getDerivedStateFromError(): Partial<ErrorBoundaryState> {
     return { hasError: true };
@@ -58,6 +63,14 @@ export class ErrorBoundary extends React.Component<
     return null;
   }
 
+  componentDidUpdate(): void {
+    if (!this.state.hasError) {
+      // 復帰したので、次に落ちたときは改めて通知する。
+      // setStateしないため、リセットのコミットは分割されない
+      this.loggedMessages.clear();
+    }
+  }
+
   componentDidCatch(error: unknown): void {
     if (this.props.fallback != null) {
       // fallbackが代わりに表示され、何が起きたかはユーザーに見えているため、
@@ -67,13 +80,17 @@ export class ErrorBoundary extends React.Component<
       return;
     }
     const message = error instanceof Error ? error.message : String(error);
-    if (message === this.loggedMessage) {
+    if (this.loggedMessages.has(message)) {
       // 再試行して同じ壊れ方で落ちただけ。通知は既に出している
       console.error(error);
       return;
     }
-    this.loggedMessage = message;
-    chromeService.errorLog.set(error).catch(console.error);
+    this.loggedMessages.add(message);
+    chromeService.errorLog.set(error).catch((e) => {
+      // 記録できていないので覚えない（次の試行で通知をやり直せる）
+      this.loggedMessages.delete(message);
+      console.error(e);
+    });
   }
 
   render(): React.ReactNode {

--- a/src/js/components/errorBoundary.tsx
+++ b/src/js/components/errorBoundary.tsx
@@ -5,6 +5,10 @@ interface ErrorBoundaryProps {
   children: React.ReactNode;
   // 例外を捕捉したときに代わりに表示する要素。省略時は何も表示しない
   fallback?: React.ReactNode;
+  // 表示をやり直す契機。捕捉後にこの値が変わったら子のレンダリングを再試行する。
+  // 呼び出し側は「落ちた原因のデータ」そのものを渡す（データが差し替わって
+  // 初めて再試行されるため、直っていないうちは何度読み直しても再試行しない）
+  resetKey?: unknown;
 }
 
 interface ErrorBoundaryState {
@@ -14,7 +18,10 @@ interface ErrorBoundaryState {
 /**
  * 子のレンダリング時例外がページ全体を巻き込んでアンマウントするのを防ぐ。
  * 捕捉した例外はerrorLogへ保存し、表示はErrorDisplayに任せる。
- * fallbackを指定した場合はそれ自体が表示になるためerrorLogへは保存しない
+ * fallbackを指定した場合はそれ自体が表示になるためerrorLogへは保存しない。
+ * 一度捕捉すると表示はfallbackに固定されるため、データが直ったら
+ * resetKeyを変えて再試行させる（境界のkeyは位置の固定に使っており、
+ * 同じ位置のデータが差し替わっても再マウントは起きない）
  */
 export class ErrorBoundary extends React.Component<
   ErrorBoundaryProps,
@@ -24,6 +31,17 @@ export class ErrorBoundary extends React.Component<
 
   static getDerivedStateFromError(): ErrorBoundaryState {
     return { hasError: true };
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    // 再試行するのは落ちている間だけ。resetKeyが変わり続けても、
+    // 落ちていない子を無駄に作り直さない
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      // 直っていなければ再試行でまた捕捉してfallbackに戻る。
+      // このとき増えるレンダリングはresetKeyが変わった1回分に留まる
+      // （propsは既に新しい値なので、この更新では再試行しない）
+      this.setState({ hasError: false });
+    }
   }
 
   componentDidCatch(error: unknown): void {

--- a/src/js/components/errorBoundary.tsx
+++ b/src/js/components/errorBoundary.tsx
@@ -5,14 +5,17 @@ interface ErrorBoundaryProps {
   children: React.ReactNode;
   // 例外を捕捉したときに代わりに表示する要素。省略時は何も表示しない
   fallback?: React.ReactNode;
-  // 表示をやり直す契機。捕捉後にこの値が変わったら子のレンダリングを再試行する。
-  // 呼び出し側は「落ちた原因のデータ」そのものを渡す（データが差し替わって
-  // 初めて再試行されるため、直っていないうちは何度読み直しても再試行しない）
+  // 表示をやり直す契機。この値が変わったら子のレンダリングを再試行する。
+  // 一覧の読み直し(#249)は内容が同じでもBlockEntryを作り直すため、
+  // 呼び出し側が落ちた原因のデータを渡すと「読み直しごとに1回再試行する」
+  // 意味になる。直っていなければ同じレンダーの中でfallbackへ戻る
   resetKey?: unknown;
 }
 
 interface ErrorBoundaryState {
   hasError: boolean;
+  // 直近のレンダリングで見たresetKey。propsとの差分でリセットを判断する
+  resetKey: unknown;
 }
 
 /**
@@ -27,21 +30,32 @@ export class ErrorBoundary extends React.Component<
   ErrorBoundaryProps,
   ErrorBoundaryState
 > {
-  state: ErrorBoundaryState = { hasError: false };
+  state: ErrorBoundaryState = {
+    hasError: false,
+    resetKey: this.props.resetKey,
+  };
 
-  static getDerivedStateFromError(): ErrorBoundaryState {
+  // 直近にerrorLogへ記録したメッセージ。同じ壊れ方で再試行するたびに
+  // 記録し直すと、利用者が閉じたアラートとバッジが読み直しごとに復活する
+  private loggedMessage: string | null = null;
+
+  static getDerivedStateFromError(): Partial<ErrorBoundaryState> {
     return { hasError: true };
   }
 
-  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
-    // 再試行するのは落ちている間だけ。resetKeyが変わり続けても、
-    // 落ちていない子を無駄に作り直さない
-    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
-      // 直っていなければ再試行でまた捕捉してfallbackに戻る。
-      // このとき増えるレンダリングはresetKeyが変わった1回分に留まる
-      // （propsは既に新しい値なので、この更新では再試行しない）
-      this.setState({ hasError: false });
+  // componentDidUpdateでリセットすると、fallbackを描いたコミットの後に
+  // 子を描き直す別のコミットが挟まる。そのコミットでは親は再レンダリング
+  // されないため、親のuseLayoutEffectが古いDOM（fallback）を見たまま
+  // 取り残される（並び替えの演出が誤発火する）。同じレンダーの中で
+  // 決着させるため、propsからstateを導出する形でリセットする
+  static getDerivedStateFromProps(
+    props: ErrorBoundaryProps,
+    state: ErrorBoundaryState,
+  ): Partial<ErrorBoundaryState> | null {
+    if (props.resetKey !== state.resetKey) {
+      return { hasError: false, resetKey: props.resetKey };
     }
+    return null;
   }
 
   componentDidCatch(error: unknown): void {
@@ -52,6 +66,13 @@ export class ErrorBoundary extends React.Component<
       console.error(error);
       return;
     }
+    const message = error instanceof Error ? error.message : String(error);
+    if (message === this.loggedMessage) {
+      // 再試行して同じ壊れ方で落ちただけ。通知は既に出している
+      console.error(error);
+      return;
+    }
+    this.loggedMessage = message;
     chromeService.errorLog.set(error).catch(console.error);
   }
 

--- a/src/js/components/main.tsx
+++ b/src/js/components/main.tsx
@@ -40,8 +40,8 @@ const Main: React.FC<MainProps> = (props) => {
             <ErrorBoundary
               key={entry.indexNum}
               // 読み直しで同じ位置のブロックが差し替わったら表示をやり直す。
-              // 参照が変わるのは中身が読み直されたブロックだけなので、
-              // 落ちていない兄弟の編集中モーダルや入力を巻き込まない
+              // 再試行が起きるのは落ちている境界だけなので、
+              // 落ちていない兄弟の編集中モーダルや入力は巻き込まない
               resetKey={entry}
               fallback={
                 <BrokenBlock

--- a/src/js/components/main.tsx
+++ b/src/js/components/main.tsx
@@ -39,6 +39,10 @@ const Main: React.FC<MainProps> = (props) => {
             // 復元できなかったブロックと同じ削除できるカードに差し替える
             <ErrorBoundary
               key={entry.indexNum}
+              // 読み直しで同じ位置のブロックが差し替わったら表示をやり直す。
+              // 参照が変わるのは中身が読み直されたブロックだけなので、
+              // 落ちていない兄弟の編集中モーダルや入力を巻き込まない
+              resetKey={entry}
               fallback={
                 <BrokenBlock
                   indexNum={entry.indexNum}


### PR DESCRIPTION
Closes #256

## 何が問題だったか

`ErrorBoundary` は `hasError` を立てたら戻す手段を持たず、境界の `key` は位置の固定（`entry.indexNum` / タブの index）に使っているため、同じ位置のデータが差し替わっても再マウントされない。#249（PR #255）で `storage.onChanged` を購読して一覧を読み直すようになったので、「他端末でデータが直ったのに `BrokenBlock` のカードが残り、出ている導線は『このブロックを削除する』だけ」という、直っているデータを消す方向へ誘導する経路が実在するようになった。PR #230 のレビューで L2 として予告されていた事象。

## 対応

issue の案1（`resetKey`）を採った。案2（境界の `key` にデータの世代を混ぜる）は落ちていない兄弟まで再マウントし、編集中のモーダルや入力中の名前を巻き込むため採らなかった。

- **`errorBoundary.tsx`**: `resetKey?: unknown` を追加し、`getDerivedStateFromProps` で前回見た値と違えば `hasError` を false に戻す。呼び出し側は世代カウンタではなく**落ちた原因のデータそのもの**を渡す。
  - `componentDidUpdate` + `setState` にしなかったのは、`fallback` を描いたコミットの後に子を描き直す**別のコミット**が挟まるため。そのコミットでは親が再レンダリングされないので、`main.tsx` の `useLayoutEffect`（`useBlockMoveAnimation`）が `BrokenBlock` の位置を記録したまま取り残され、次のレンダリングで並び替えの演出が誤発火する。props から state を導出すれば同じレンダーの中で決着する。
- **`main.tsx`**: ブロック単位の境界に `resetKey={entry}`。再試行が起きるのは落ちている境界だけなので、落ちていない兄弟の編集中モーダルや入力は巻き込まない。
- **`block.tsx`**: タブ単位の境界に `resetKey={tab}`。`key` は `${index}-${tab.url}` なので url が変われば再マウントされるが、**同じ url のまま title だけ直った**ケースは key では拾えない。
- **`app.tsx`**: `Main` を囲む境界に `resetKey={sortedBlocks}`。ここは `fallback` が無く、一度落ちると一覧そのものが失われるため復帰の必要が最も大きい。読み直し・自操作の更新で配列参照が変わるので、専用の世代 state は持たせていない。
- **通知の抑制**: `fallback` の無い境界は捕捉した例外を `errorLog`（バッジ+アラート）へ記録する。再試行して同じ壊れ方で落ちるたびに記録し直すと、利用者が閉じたアラートが読み直しごとに復活するため、**落ちている間の同じメッセージは記録し直さない**。復帰したら覚えていたメッセージは忘れる（復帰後の障害は通知が必要。とくにこの境界は `fallback` が無いので、黙ると一覧が空になったのに手掛かりが何も出ない）。`errorLog.set` 自体が失敗したときも覚えない。

**収束性**（issue で確認を求められていた点）: 一覧の読み直しは内容が同じでも `BlockEntry` を作り直すため、`resetKey` は読み直しごとに変わる。つまり**読み直し1回につき再試行1回**で、直っていなければ同じレンダーパスの中で `fallback` へ戻る（`getDerivedStateFromProps` の時点で `state.resetKey` が既に新しい値なので再リセットしない）。無限ループ・レンダリング振動は起きない。これはテストで固定した。

## テスト

- `errorBoundary.test.tsx`（新規）: 捕捉後に `resetKey` が変われば再試行する／変わらなければ `fallback` のまま／`resetKey` を渡さない呼び出しは従来どおり固定される／**直っていないデータで再試行しても `fallback` に収束し、レンダリング回数が再試行1回分しか増えない**／落ちていなければ子を作り直さない／**復帰が親のレイアウト測定と同じコミットで終わる**（`componentDidUpdate` 方式だと落ちる）／同じ壊れ方では `errorLog` へ記録し直さない／復帰後に同じメッセージで落ちたら改めて記録する／記録に失敗したら次の試行でやり直す
- `app.test.tsx`: 読み直しでデータが直ったブロックがカードから一覧に戻る／直っていないブロックはカードのまま残り再試行が回り続けない／`Main` 全体が落ちても読み直しで一覧が戻る
- `block.test.tsx`: 同じ url のまま title だけ直ったタブが `BrokenTab` から復帰する／直っていないタブは読み直しごとに1回だけ再試行してカードのまま

`npm run format:check` / `npm run lint` / `npm test`（271件）/ `npx tsc --noEmit` はローカルで通っている。ミューテーションも確認済み: リセット判定を外すと6件、リセットを別コミットに分けると1件、通知の抑制／復帰時のクリア／記録失敗時の巻き戻しを外すとそれぞれ1件が落ちる。

## 意図的に直していない点

- **`resetKey` がオブジェクト参照の変化に依存する**: 将来 `getAllBlock()` が同一参照を返すキャッシュを持つと効かなくなる。明示的な世代カウンタのほうが堅いが、`main.tsx` ではブロック単位の粒度が失われて落ちていない兄弟まで巻き込むため、参照依存を選んだ。レンダリングごとに作り直す値を渡すと収束しなくなるため、その注意は props のコメントに書いた。
- **再試行で `fallback` の DOM ノードが作り直される**: `BrokenTab` / `BrokenBlock` は `data-uk-icon` で UIkit に SVG を注入させているため、読み直しのたびにアイコンが作り直される。UIkit が新しいノードを再初期化するかは自動テストでは確認できていない（下の手動確認に入れた）。
- **壊れたデータの読み直しでコンソールにログが積む**: インポートのようにブロック1件ごとに書く操作では読み直しが何度も走り、そのたびに壊れた境界の数だけ React のエラーログが出る。収束はするので機能上の問題ではない。
- **`BrokenBlock` のカードに「再読み込み」導線を足す**: この issue の範囲は自動復帰なので入れていない。
- **`fallback` 自身が落ちる場合**（i18n キー欠落など）: 境界は自分の `fallback` の例外を捕まえられないので `app.tsx` の境界まで伝播して一覧が消える。#230 由来の弱点で、この変更で読み直し回数だけ増幅される。塞ぐには `fallback` をさらに境界で包む必要があり、範囲外と判断した。

## 手動確認のお願い

- tabs.html を開いた状態で devtools から `chrome.storage.sync.set` で壊れたブロック（例: `createdAt` が壊れたデータ）を書き、カードが出ることを確認 → そのまま正常なデータに書き換えて、**リロードせずに**タブの一覧へ戻ること
- 壊れたまま別のキーを書き換えたとき、カードが残ったままで画面が点滅・振動しないこと。**カードのアイコン（削除・閉じる）の見た目と行の高さが崩れないこと**（UIkit の SVG が作り直される経路）
- 別のブロックの名前を編集中・タブ編集モーダルを開いている最中に上記の復帰が起きても、入力中の文字とモーダルが消えないこと
- 壊れたデータのまま何度も読み直したあと、アラートを × で閉じたら復活しないこと
