### PR TITLE
ブロック一覧の単一ソースをt_lenからtd_Nキーの集合へ移す

### DIFF
--- a/src/js/background.test.ts
+++ b/src/js/background.test.ts
@@ -75,7 +75,7 @@ describe('background action.onClicked', (): void => {
       windows: { update: jest.fn() },
     };
     const { chromeService } = await import('./chromeService');
-    jest.spyOn(chromeService.storage, 'getTabLength').mockResolvedValue(3);
+    jest.spyOn(chromeService.storage, 'getNextBlockIndex').mockResolvedValue(3);
     jest
       .spyOn(chromeService.storage, 'setBlock')
       .mockImplementation((block) => {

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -18,7 +18,7 @@ function handleError(error: unknown): void {
  * @return {Promise<void>}
  */
 async function saveWindowTabs(windowId: number): Promise<void> {
-  const tabLength = await chromeService.storage.getTabLength();
+  const nextIndex = await chromeService.storage.getNextBlockIndex();
   // tabsページ自身は保存も終了もしない。保存対象に含めると一覧の中に
   // 一覧ページへのリンクが並んでしまい、終了対象に含めると
   // 切り替えた直後のtabsページを閉じてしまう。
@@ -34,9 +34,9 @@ async function saveWindowTabs(windowId: number): Promise<void> {
   // 空のブロックを書くとindexだけ進んで無駄な欠番が増えるため、
   // tabsページへの切り替えだけを行う
   if (currentTabs.length > 0) {
-    const block = blockService.createBlock(currentTabs, new Date(), tabLength);
+    const block = blockService.createBlock(currentTabs, new Date(), nextIndex);
     await chromeService.storage.setBlock(block);
-    await chromeService.storage.setTabLength(tabLength + 1);
+    await chromeService.storage.setTabLength(nextIndex + 1);
   }
   // このウィンドウのタブはこれから閉じる。別ウィンドウのtabsページを
   // フォーカスするだけで済ませると、最後のタブまで閉じてウィンドウごと消える

--- a/src/js/blockService.test.ts
+++ b/src/js/blockService.test.ts
@@ -763,15 +763,15 @@ describe('blockService 旧形式ゴールデンフィクスチャ(実データ�
 
 describe('blockService import/export', (): void => {
   let getAllBlockSpy: jest.SpyInstance;
-  let getTabLengthSpy: jest.SpyInstance;
+  let getNextBlockIndexSpy: jest.SpyInstance;
   let setBlockSpy: jest.SpyInstance;
   let setTabLengthSpy: jest.SpyInstance;
   const reload = jest.fn();
 
   beforeEach(() => {
     getAllBlockSpy = jest.spyOn(chromeService.storage, 'getAllBlock');
-    getTabLengthSpy = jest
-      .spyOn(chromeService.storage, 'getTabLength')
+    getNextBlockIndexSpy = jest
+      .spyOn(chromeService.storage, 'getNextBlockIndex')
       .mockResolvedValue(3);
     setBlockSpy = jest
       .spyOn(chromeService.storage, 'setBlock')
@@ -795,7 +795,7 @@ describe('blockService import/export', (): void => {
 
   afterEach(() => {
     getAllBlockSpy.mockRestore();
-    getTabLengthSpy.mockRestore();
+    getNextBlockIndexSpy.mockRestore();
     setBlockSpy.mockRestore();
     setTabLengthSpy.mockRestore();
   });

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -334,8 +334,7 @@ export namespace blockService {
   }
 
   export async function importAllDataJson(jsonStr: string): Promise<void> {
-    const tabLength = await chromeService.storage.getTabLength();
-    const idx = tabLength;
+    const nextIndex = await chromeService.storage.getNextBlockIndex();
 
     const json = JSON.parse(jsonStr);
     let blockObjs: BlockJson[];
@@ -348,9 +347,10 @@ export namespace blockService {
       }
       blockObjs = json.blocks;
     }
-    // 1件でも書き込めないブロックが混ざっていると、一部だけ書き込まれた状態で
-    // setTabLengthに到達せず、書き込んだブロックが一覧に出ないまま
-    // 次回保存で上書きされる。スキーマ由来のものは書き込む前にまとめて弾く。
+    // 1件でも書き込めないブロックが混ざっていると一部だけ書き込まれた状態になる。
+    // 書き込めた分は一覧に出るようになった（採番も保存済みindexの最大値+1なので
+    // 次回保存で上書きされない）が、途中で例外になると残りが書き込まれないため、
+    // スキーマ由来のものは書き込む前にまとめて弾く。
     // 書き込み自体の失敗（8KB制限超過など）による部分書き込みは別課題
     if (!Array.isArray(blockObjs)) {
       throw new Error('Invalid data: blocks is not an array');
@@ -358,12 +358,12 @@ export namespace blockService {
     if (blockObjs.some((obj) => !Array.isArray(obj?.tabs))) {
       throw new Error('Invalid data: block has no tabs array');
     }
-    const blocks = blockListForJsonObject(blockObjs, idx);
+    const blocks = blockListForJsonObject(blockObjs, nextIndex);
 
     await Promise.all(
       blocks.map((block) => chromeService.storage.setBlock(block)),
     );
-    await chromeService.storage.setTabLength(tabLength + blockObjs.length);
+    await chromeService.storage.setTabLength(nextIndex + blockObjs.length);
     chrome.tabs.reload({ bypassCache: true });
   }
 }

--- a/src/js/chromeService.test.ts
+++ b/src/js/chromeService.test.ts
@@ -119,7 +119,11 @@ describe('chromeService.storage.getAllBlock', (): void => {
     (global as any).chrome = {
       storage: {
         sync: {
-          get: (keys: string[]): Promise<{ [key: string]: string }> => {
+          // 実際のchrome.storage.syncと同じく、nullを渡されたら全キーを返す
+          get: (keys: string[] | null): Promise<{ [key: string]: string }> => {
+            if (keys == null) {
+              return Promise.resolve({ ...syncData });
+            }
             const res: { [key: string]: string } = {};
             for (const key of keys) {
               const value = syncData[key];
@@ -243,6 +247,108 @@ describe('chromeService.storage.getAllBlock', (): void => {
         tabs: [{ url: 'https://example.com/valid', title: 'valid' }],
       },
     ]);
+  });
+
+  // t_lenは採番カウンタでしかなく、書き込み失敗や旧形式で壊れうる。
+  // これを走査範囲にしていたころは、getTabLengthの例外がapp.tsxの.catchへ
+  // 落ちて一覧が丸ごと表示されなくなっていた(#229)
+  test.each([
+    ['数値にできない値', 'broken'],
+    ['空文字列', ''],
+    ['負の数', '-3'],
+    ['実データより小さい', '1'],
+    ['実データより大きい', '99'],
+  ])(
+    't_lenが%sでも保存されているブロックは全件返る',
+    async (_name: string, tabLength: string): Promise<void> => {
+      syncData['t_len'] = tabLength;
+      syncData['td_0'] = validJson(1609556645678, 'old');
+      syncData['td_1'] = validJson(1640000000000, 'new');
+
+      const res = await chromeService.storage.getAllBlock();
+
+      expect(res.map((entry) => entry.indexNum)).toEqual([1, 0]);
+    },
+  );
+
+  test('t_lenが保存されていなくてもブロックは全件返る', async (): Promise<void> => {
+    syncData['td_0'] = validJson(1609556645678, 'old');
+    syncData['td_1'] = validJson(1640000000000, 'new');
+
+    const res = await chromeService.storage.getAllBlock();
+
+    expect(res.map((entry) => entry.indexNum)).toEqual([1, 0]);
+  });
+
+  test('ブロック以外のキーは一覧に含めない', async (): Promise<void> => {
+    syncData['t_len'] = '1';
+    syncData['error'] = 'boom';
+    syncData['td_x'] = validJson(1609556645678, 'notablock');
+    syncData['td_0'] = validJson(1640000000000, 'valid');
+
+    const res = await chromeService.storage.getAllBlock();
+
+    expect(res.map((entry) => entry.indexNum)).toEqual([0]);
+  });
+});
+
+describe('chromeService.storage.getNextBlockIndex', (): void => {
+  let syncData: { [key: string]: string };
+
+  beforeEach((): void => {
+    syncData = {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      storage: {
+        sync: {
+          get: (keys: string[] | null): Promise<{ [key: string]: string }> => {
+            if (keys == null) {
+              return Promise.resolve({ ...syncData });
+            }
+            const res: { [key: string]: string } = {};
+            for (const key of keys) {
+              const value = syncData[key];
+              if (value != null) {
+                res[key] = value;
+              }
+            }
+            return Promise.resolve(res);
+          },
+        },
+      },
+    };
+  });
+
+  test('1件も保存されていなければ0を返す', async (): Promise<void> => {
+    syncData['t_len'] = '5';
+
+    expect(await chromeService.storage.getNextBlockIndex()).toBe(0);
+  });
+
+  test('保存済みindexの最大値+1を返す', async (): Promise<void> => {
+    syncData['td_0'] = 'dummy';
+    syncData['td_1'] = 'dummy';
+
+    expect(await chromeService.storage.getNextBlockIndex()).toBe(2);
+  });
+
+  // 削除でindexに穴が空いてもt_lenは減らないため、
+  // 欠番をまたいで最大値を見ないと既存ブロックを上書きしてしまう
+  test('欠番があっても既存のindexを再利用しない', async (): Promise<void> => {
+    syncData['td_0'] = 'dummy';
+    syncData['td_3'] = 'dummy';
+
+    expect(await chromeService.storage.getNextBlockIndex()).toBe(4);
+  });
+
+  // t_lenの外側に取り残されたブロックを上書きしないことの回帰テスト(#232)
+  test('t_lenが実データより小さくても上書きしないindexを返す', async (): Promise<void> => {
+    syncData['t_len'] = '1';
+    syncData['td_0'] = 'dummy';
+    syncData['td_1'] = 'dummy';
+    syncData['td_2'] = 'dummy';
+
+    expect(await chromeService.storage.getNextBlockIndex()).toBe(3);
   });
 });
 

--- a/src/js/chromeService.test.ts
+++ b/src/js/chromeService.test.ts
@@ -97,7 +97,8 @@ describe('chromeService.errorLog', (): void => {
 });
 
 describe('chromeService.storage.getAllBlock', (): void => {
-  let syncData: { [key: string]: string };
+  // storageが壊れていれば文字列以外も返りうるため、値の型は絞らない
+  let syncData: { [key: string]: unknown };
   let consoleErrorSpy: jest.SpyInstance;
 
   // 正常に復元できる非圧縮v2ブロックのJSON
@@ -120,11 +121,11 @@ describe('chromeService.storage.getAllBlock', (): void => {
       storage: {
         sync: {
           // 実際のchrome.storage.syncと同じく、nullを渡されたら全キーを返す
-          get: (keys: string[] | null): Promise<{ [key: string]: string }> => {
+          get: (keys: string[] | null): Promise<{ [key: string]: unknown }> => {
             if (keys == null) {
               return Promise.resolve({ ...syncData });
             }
-            const res: { [key: string]: string } = {};
+            const res: { [key: string]: unknown } = {};
             for (const key of keys) {
               const value = syncData[key];
               if (value != null) {
@@ -234,7 +235,8 @@ describe('chromeService.storage.getAllBlock', (): void => {
     ]);
   });
 
-  test('keyが存在しないブロックは削除済みとして一覧に含めない', async (): Promise<void> => {
+  // 削除済みのブロックはkeyごと消えるため、indexに穴が空く
+  test('indexに欠番があっても残りのブロックは返る', async (): Promise<void> => {
     syncData['t_len'] = '2';
     syncData['td_1'] = validJson(1640000000000, 'valid');
 
@@ -280,6 +282,64 @@ describe('chromeService.storage.getAllBlock', (): void => {
     expect(res.map((entry) => entry.indexNum)).toEqual([1, 0]);
   });
 
+  // indexへ数値化するとtabKey()が元のキーに戻せないキーを一覧に出すと、
+  // 書き戻しが別のキーへ行って同じブロックが2枚に増え、
+  // 元のキーはUIから削除できないまま残る
+  test.each([
+    ['先頭ゼロ', 'td_007'],
+    ['安全な整数を超える桁数', 'td_111111111111111111111'],
+  ])(
+    'indexへ往復できないキー(%s)は一覧に含めない',
+    async (_name: string, key: string): Promise<void> => {
+      syncData[key] = validJson(1609556645678, 'zombie');
+      syncData['td_0'] = validJson(1640000000000, 'valid');
+
+      const res = await chromeService.storage.getAllBlock();
+
+      expect(res.map((entry) => entry.indexNum)).toEqual([0]);
+    },
+  );
+
+  test('td_0とtd_00が両方あってもtd_0だけを返す', async (): Promise<void> => {
+    syncData['td_0'] = validJson(1640000000000, 'valid');
+    syncData['td_00'] = validJson(1609556645678, 'zombie');
+
+    const res = await chromeService.storage.getAllBlock();
+
+    expect(res).toStrictEqual([
+      {
+        indexNum: 0,
+        createdAt: new Date(1640000000000),
+        tabs: [{ url: 'https://example.com/valid', title: 'valid' }],
+      },
+    ]);
+  });
+
+  // 保存データは文字列だが、storageが壊れていれば別の型で返りうる。
+  // inflateEntryをすり抜けて一覧全体をrejectさせないことを担保する(#192)
+  test.each([
+    ['数値', 42],
+    ['null', null],
+    ['真偽値', true],
+    ['オブジェクト', { tabs: [] }],
+    ['配列', []],
+  ])(
+    '保存データが文字列でない(%s)場合もBrokenBlockとして返る',
+    async (_name: string, brokenValue: unknown): Promise<void> => {
+      syncData['td_0'] = brokenValue;
+      syncData['td_1'] = validJson(1640000000000, 'valid');
+
+      const res = await chromeService.storage.getAllBlock();
+
+      expect(res).toHaveLength(2);
+      expect(res[1]).toStrictEqual({
+        indexNum: 0,
+        broken: true,
+        unsupported: false,
+      });
+    },
+  );
+
   test('ブロック以外のキーは一覧に含めない', async (): Promise<void> => {
     syncData['t_len'] = '1';
     syncData['error'] = 'boom';
@@ -319,9 +379,7 @@ describe('chromeService.storage.getNextBlockIndex', (): void => {
     };
   });
 
-  test('1件も保存されていなければ0を返す', async (): Promise<void> => {
-    syncData['t_len'] = '5';
-
+  test('1件も保存されておらずt_lenもなければ0を返す', async (): Promise<void> => {
     expect(await chromeService.storage.getNextBlockIndex()).toBe(0);
   });
 
@@ -330,6 +388,42 @@ describe('chromeService.storage.getNextBlockIndex', (): void => {
     syncData['td_1'] = 'dummy';
 
     expect(await chromeService.storage.getNextBlockIndex()).toBe(2);
+  });
+
+  // 全件削除したあとにindexを0から振り直すと、同期の遅れた端末が持つ
+  // 古いtd_0の書き戻しとキーが衝突し、保存したばかりのブロックが
+  // 古いもので上書きされうる。t_lenを下限として見て単調性を保つ
+  test('全件削除されていてもt_lenの分だけindexを進める', async (): Promise<void> => {
+    syncData['t_len'] = '5';
+
+    expect(await chromeService.storage.getNextBlockIndex()).toBe(5);
+  });
+
+  // t_lenが壊れていても採番は止めない(#229)
+  test.each([
+    ['数値にできない値', 'broken'],
+    ['空文字列', ''],
+    ['負の数', '-3'],
+    ['小数', '1.5'],
+    ['安全な整数を超える値', '1e21'],
+  ])(
+    't_lenが%sでも保存済みindexから採番する',
+    async (_name: string, tabLength: string): Promise<void> => {
+      syncData['t_len'] = tabLength;
+      syncData['td_0'] = 'dummy';
+
+      expect(await chromeService.storage.getNextBlockIndex()).toBe(1);
+    },
+  );
+
+  // 数値化するとtabKey()が元のキーに戻せないキーを採番に混ぜると、
+  // 桁あふれでindexが増えなくなり同じキーを上書きし続ける
+  test('indexへ往復できないキーは採番の手がかりにしない', async (): Promise<void> => {
+    syncData['td_111111111111111111111'] = 'dummy';
+    syncData['td_007'] = 'dummy';
+    syncData['td_2'] = 'dummy';
+
+    expect(await chromeService.storage.getNextBlockIndex()).toBe(3);
   });
 
   // 削除でindexに穴が空いてもt_lenは減らないため、

--- a/src/js/chromeService.test.ts
+++ b/src/js/chromeService.test.ts
@@ -288,6 +288,8 @@ describe('chromeService.storage.getAllBlock', (): void => {
   test.each([
     ['先頭ゼロ', 'td_007'],
     ['安全な整数を超える桁数', 'td_111111111111111111111'],
+    // 文字列としては往復するが、+1しても増えないためindexとして使えない
+    ['安全な整数の直上', 'td_9007199254740992'],
   ])(
     'indexへ往復できないキー(%s)は一覧に含めない',
     async (_name: string, key: string): Promise<void> => {
@@ -299,6 +301,16 @@ describe('chromeService.storage.getAllBlock', (): void => {
       expect(res.map((entry) => entry.indexNum)).toEqual([0]);
     },
   );
+
+  // 弾く側だけを固定すると、正常な大きいindexまで巻き添えにする変更が
+  // テストをすり抜ける
+  test('安全な整数の範囲内なら大きいindexでも一覧に含める', async (): Promise<void> => {
+    syncData['td_9007199254740991'] = validJson(1640000000000, 'valid');
+
+    const res = await chromeService.storage.getAllBlock();
+
+    expect(res.map((entry) => entry.indexNum)).toEqual([9007199254740991]);
+  });
 
   test('td_0とtd_00が両方あってもtd_0だけを返す', async (): Promise<void> => {
     syncData['td_0'] = validJson(1640000000000, 'valid');
@@ -424,6 +436,26 @@ describe('chromeService.storage.getNextBlockIndex', (): void => {
     syncData['td_2'] = 'dummy';
 
     expect(await chromeService.storage.getNextBlockIndex()).toBe(3);
+  });
+
+  // 安全な整数を超えるindexで保存すると、書いたキーを読み戻せなくなり、
+  // 保存したブロックが一覧にも出ず削除もできなくなる。
+  // 単調性を諦めてでも、読み書きできるindexを返す
+  test('indexをこれ以上進められないときは空いている最小のindexを返す', async (): Promise<void> => {
+    syncData['td_9007199254740991'] = 'dummy';
+
+    const res = await chromeService.storage.getNextBlockIndex();
+
+    expect(Number.isSafeInteger(res)).toBe(true);
+    expect(res).toBe(0);
+  });
+
+  test('空いている最小のindexを探すとき使用中のindexは飛ばす', async (): Promise<void> => {
+    syncData['td_9007199254740991'] = 'dummy';
+    syncData['td_0'] = 'dummy';
+    syncData['td_1'] = 'dummy';
+
+    expect(await chromeService.storage.getNextBlockIndex()).toBe(2);
   });
 
   // 削除でindexに穴が空いてもt_lenは減らないため、

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -70,18 +70,20 @@ export namespace chromeService {
      * 「t_lenが壊れると一覧が全滅する」「t_lenの外側のブロックが
      * 一覧に出ないまま次回保存で上書きされる」という取りこぼしが起きる
      * @param {{[key: string]: unknown}} items storage.syncの全アイテム
-     * @return {[number, string][]} [index, 保存データ]の配列。indexの昇順
+     * @return {[number, unknown][]} [index, 保存データ]の配列。indexの昇順
      */
     function blockDataOf(items: {
       [key: string]: unknown;
-    }): [number, string][] {
-      const blockData: [number, string][] = [];
+    }): [number, unknown][] {
+      const blockData: [number, unknown][] = [];
       for (const [key, value] of Object.entries(items)) {
         const indexNum = blockIndexOf(key);
         if (indexNum == null) {
           continue;
         }
-        blockData.push([indexNum, value as string]);
+        // 保存しているのは文字列だが、storageが壊れていれば別の型で返る。
+        // 型を偽らずinflateEntryに判定させる
+        blockData.push([indexNum, value]);
       }
       // キーの列挙順は辞書順(td_10がtd_2より前)なので、そのまま流すと
       // compareBlockEntryが同着と判定するブロックの並びが
@@ -93,9 +95,11 @@ export namespace chromeService {
      * 採番の下限としてt_lenを読む。
      * t_lenは互換のために書き続けている「使用済みかもしれない範囲」の
      * 手がかりでしかなく、一覧の走査範囲には使わない。
-     * これを無視すると全件削除のあとにindexが0から再利用され、
-     * 同期の遅れた端末が持つ古いtd_0の書き戻しとキーが衝突して、
+     * これを無視すると、末尾のブロックを削除したあとに同じindexが
+     * 再利用され、同期の遅れた端末が持つ古い同じキーの書き戻しと衝突して、
      * 保存したばかりのブロックが古いもので上書きされうる。
+     * （storage.syncごと消すallClearではt_lenも消えるため、
+     * 全データ削除のあとのindexは0に戻る。そこはこの手がかりの守備範囲外）
      * 壊れていても採番は止めてはいけないので、
      * 数値にできない値は手がかりなし(0)として扱う
      * @param {{[key: string]: unknown}} items storage.syncの全アイテム
@@ -107,6 +111,22 @@ export namespace chromeService {
         return 0;
       }
       return tabLength;
+    }
+
+    /**
+     * まだ使われていない最小のindexを返す。
+     * indexを単調に進められなくなったときの逃げ道なので、
+     * 空いている番号を埋める形で採番する
+     * @param {[number, unknown][]} blockData 保存されているブロックのデータ
+     * @return {number} 未使用のindex
+     */
+    function smallestUnusedIndex(blockData: [number, unknown][]): number {
+      const used = new Set(blockData.map(([indexNum]) => indexNum));
+      let indexNum = 0;
+      while (used.has(indexNum)) {
+        indexNum += 1;
+      }
+      return indexNum;
     }
 
     export async function setBlock(block: model.Block): Promise<void> {
@@ -160,10 +180,18 @@ export namespace chromeService {
      */
     export async function getNextBlockIndex(): Promise<number> {
       const items = await getAllSyncItems();
-      return blockDataOf(items).reduce(
+      const blockData = blockDataOf(items);
+      const nextIndex = blockData.reduce(
         (next, [indexNum]) => Math.max(next, indexNum + 1),
         tabLengthHintOf(items),
       );
+      if (Number.isSafeInteger(nextIndex)) {
+        return nextIndex;
+      }
+      // 安全な整数を超えるindexで保存すると、書いたキーをblockIndexOfが
+      // 拾えなくなり、保存したブロックが一覧にも出ず削除もできなくなる。
+      // ここまで来たらindexの単調性は諦めて、空いている番号を使う
+      return smallestUnusedIndex(blockData);
     }
 
     export async function getAllBlock(): Promise<model.BlockEntry[]> {
@@ -178,15 +206,20 @@ export namespace chromeService {
     /**
      * 保存データ1件を復元する。復元に失敗した場合は例外を伝播させず
      * BrokenBlockを返す（1件の壊れたデータで一覧全体が失われないようにする）
-     * @param {string} json 保存されていたデータ
+     * @param {unknown} json 保存されていたデータ
      * @param {number} indexNum ブロックのindex
      * @return {Promise<model.BlockEntry>} 復元したBlock or BrokenBlock
      */
     async function inflateEntry(
-      json: string,
+      json: unknown,
       indexNum: number,
     ): Promise<model.BlockEntry> {
       try {
+        if (typeof json !== 'string') {
+          throw new Error(
+            `Invalid block data: not a string, index=${indexNum}`,
+          );
+        }
         if (json.length <= 0) {
           throw new Error(`Empty block data: index=${indexNum}`);
         }

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -33,27 +33,80 @@ export namespace chromeService {
     }
 
     /**
+     * storage.syncに保存されている全アイテムを取得する。
+     * 個別にgetすると保存件数だけ往復するうえ、件数を先に知る必要がある
+     * @return {Promise<{[key: string]: unknown}>} キーと保存されている値
+     */
+    async function getAllSyncItems(): Promise<{ [key: string]: unknown }> {
+      return chrome.storage.sync.get(null);
+    }
+
+    /**
+     * ブロックの保存データのキーならそのindexを、そうでなければnullを返す。
+     * td_007のような先頭ゼロや、安全な整数を超える桁数のキーは、
+     * indexへ数値化するとtabKey()が元のキーに戻せない。これを拾うと
+     * 書き戻しが別のキーへ行って同じブロックが2枚に増え、
+     * 元のキーはUIから削除できないまま残るため、ブロックとして扱わない
+     * @param {string} key storage.syncのキー
+     * @return {number | null} ブロックのindex。ブロックでなければnull
+     */
+    function blockIndexOf(key: string): number | null {
+      const matched = tabKeyPattern.exec(key);
+      if (matched == null) {
+        return null;
+      }
+      const indexNum = Number(matched[1]);
+      if (!Number.isSafeInteger(indexNum) || tabKey(indexNum) !== key) {
+        return null;
+      }
+      return indexNum;
+    }
+
+    /**
      * 保存されているブロックのデータを、キーの一覧から集める。
      * 件数はt_lenではなくtd_Nキーの集合そのものを単一のソースとする。
      * t_lenは採番カウンタでしかなく、削除で減らないうえに書き込み失敗で
      * 実データとずれるため、これを走査範囲にすると
      * 「t_lenが壊れると一覧が全滅する」「t_lenの外側のブロックが
      * 一覧に出ないまま次回保存で上書きされる」という取りこぼしが起きる
-     * @return {Promise<[number, string][]>} [index, 保存データ]の配列
+     * @param {{[key: string]: unknown}} items storage.syncの全アイテム
+     * @return {[number, string][]} [index, 保存データ]の配列。indexの昇順
      */
-    async function getAllBlockData(): Promise<[number, string][]> {
-      // 個別にgetすると保存件数だけ往復するうえ、件数を先に知る必要がある。
-      // nullを渡して全キーを1回で引き、td_Nだけを拾う
-      const items = await chrome.storage.sync.get(null);
+    function blockDataOf(items: {
+      [key: string]: unknown;
+    }): [number, string][] {
       const blockData: [number, string][] = [];
       for (const [key, value] of Object.entries(items)) {
-        const matched = tabKeyPattern.exec(key);
-        if (matched == null) {
+        const indexNum = blockIndexOf(key);
+        if (indexNum == null) {
           continue;
         }
-        blockData.push([Number(matched[1]), value as string]);
+        blockData.push([indexNum, value as string]);
       }
-      return blockData;
+      // キーの列挙順は辞書順(td_10がtd_2より前)なので、そのまま流すと
+      // compareBlockEntryが同着と判定するブロックの並びが
+      // storageの内部順に左右される
+      return blockData.sort((a, b) => a[0] - b[0]);
+    }
+
+    /**
+     * 採番の下限としてt_lenを読む。
+     * t_lenは互換のために書き続けている「使用済みかもしれない範囲」の
+     * 手がかりでしかなく、一覧の走査範囲には使わない。
+     * これを無視すると全件削除のあとにindexが0から再利用され、
+     * 同期の遅れた端末が持つ古いtd_0の書き戻しとキーが衝突して、
+     * 保存したばかりのブロックが古いもので上書きされうる。
+     * 壊れていても採番は止めてはいけないので、
+     * 数値にできない値は手がかりなし(0)として扱う
+     * @param {{[key: string]: unknown}} items storage.syncの全アイテム
+     * @return {number} 採番の下限
+     */
+    function tabLengthHintOf(items: { [key: string]: unknown }): number {
+      const tabLength = Number(items[tabLengthKey]);
+      if (!Number.isSafeInteger(tabLength) || tabLength <= 0) {
+        return 0;
+      }
+      return tabLength;
     }
 
     export async function setBlock(block: model.Block): Promise<void> {
@@ -89,9 +142,9 @@ export namespace chromeService {
 
     /**
      * 次に保存するブロックのindexを書き込む。
-     * この拡張自身はもうt_lenを読まないが、storage.syncは複数の端末で
-     * 共有されるため、まだ更新前のバージョンが動いている端末で
-     * 一覧が欠けないよう書き込みだけは続ける
+     * この拡張自身は一覧の走査にt_lenを使わなくなったが、storage.syncは
+     * 複数の端末で共有されるため、まだ更新前のバージョンが動いている端末で
+     * 一覧が欠けないよう書き込みは続ける（採番の下限としても読む）
      * @param {number} value 次に保存するブロックのindex
      * @return {Promise<void>}
      */
@@ -106,15 +159,15 @@ export namespace chromeService {
      * @return {Promise<number>} 未使用のindex
      */
     export async function getNextBlockIndex(): Promise<number> {
-      const blockData = await getAllBlockData();
-      return blockData.reduce(
+      const items = await getAllSyncItems();
+      return blockDataOf(items).reduce(
         (next, [indexNum]) => Math.max(next, indexNum + 1),
-        0,
+        tabLengthHintOf(items),
       );
     }
 
     export async function getAllBlock(): Promise<model.BlockEntry[]> {
-      const blockData = await getAllBlockData();
+      const blockData = blockDataOf(await getAllSyncItems());
       const entries = await Promise.all(
         // 空文字列は書き込みが壊れた形跡なのでBrokenBlockとして扱う
         blockData.map(([indexNum, json]) => inflateEntry(json, indexNum)),

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -1,11 +1,11 @@
 import { model } from './types/interface';
 import { blockService } from './blockService';
-import { util } from './util';
 
 export namespace chromeService {
   export namespace storage {
     const tabLengthKey: string = 't_len';
     const tabKey = (index: number): string => `td_${index}`;
+    const tabKeyPattern = /^td_(\d+)$/;
 
     /**
      * storage.syncのキーがブロック一覧の内容に関わるものかを返す。
@@ -15,7 +15,7 @@ export namespace chromeService {
      * @return {boolean} ブロックの保存データ or ブロック数のキーならtrue
      */
     export function isBlockDataKey(key: string): boolean {
-      return key === tabLengthKey || /^td_\d+$/.test(key);
+      return key === tabLengthKey || tabKeyPattern.test(key);
     }
 
     function deleteSyncStorage(key: string): Promise<void> {
@@ -28,22 +28,32 @@ export namespace chromeService {
       return chrome.storage.sync.set(setObj);
     }
 
-    async function getSyncStorage(key: string): Promise<string> {
-      const item = await chrome.storage.sync.get([key]);
-      return item[key] as string;
-    }
-
     export async function allClear(): Promise<void> {
       return chrome.storage.sync.clear();
     }
 
-    function getSyncStorageReturnIndex(
-      index: number,
-    ): Promise<[number, string]> {
-      const key = tabKey(index);
-      return getSyncStorage(key).then((result) => {
-        return [index, result];
-      });
+    /**
+     * 保存されているブロックのデータを、キーの一覧から集める。
+     * 件数はt_lenではなくtd_Nキーの集合そのものを単一のソースとする。
+     * t_lenは採番カウンタでしかなく、削除で減らないうえに書き込み失敗で
+     * 実データとずれるため、これを走査範囲にすると
+     * 「t_lenが壊れると一覧が全滅する」「t_lenの外側のブロックが
+     * 一覧に出ないまま次回保存で上書きされる」という取りこぼしが起きる
+     * @return {Promise<[number, string][]>} [index, 保存データ]の配列
+     */
+    async function getAllBlockData(): Promise<[number, string][]> {
+      // 個別にgetすると保存件数だけ往復するうえ、件数を先に知る必要がある。
+      // nullを渡して全キーを1回で引き、td_Nだけを拾う
+      const items = await chrome.storage.sync.get(null);
+      const blockData: [number, string][] = [];
+      for (const [key, value] of Object.entries(items)) {
+        const matched = tabKeyPattern.exec(key);
+        if (matched == null) {
+          continue;
+        }
+        blockData.push([Number(matched[1]), value as string]);
+      }
+      return blockData;
     }
 
     export async function setBlock(block: model.Block): Promise<void> {
@@ -77,36 +87,37 @@ export namespace chromeService {
       return setSyncStorage(key, data);
     }
 
+    /**
+     * 次に保存するブロックのindexを書き込む。
+     * この拡張自身はもうt_lenを読まないが、storage.syncは複数の端末で
+     * 共有されるため、まだ更新前のバージョンが動いている端末で
+     * 一覧が欠けないよう書き込みだけは続ける
+     * @param {number} value 次に保存するブロックのindex
+     * @return {Promise<void>}
+     */
     export async function setTabLength(value: number): Promise<void> {
       return setSyncStorage(tabLengthKey, value.toString());
     }
 
-    export async function getTabLength(): Promise<number> {
-      return getSyncStorage(tabLengthKey).then((result) => {
-        if (result == null) {
-          return 0;
-        } else {
-          return util.toNumber(result);
-        }
-      });
+    /**
+     * 次に保存するブロックに割り当てるindexを返す。
+     * 保存済みのindexの最大値+1とすることで、t_lenが実データと
+     * ずれていても既存のブロックを上書きしない
+     * @return {Promise<number>} 未使用のindex
+     */
+    export async function getNextBlockIndex(): Promise<number> {
+      const blockData = await getAllBlockData();
+      return blockData.reduce(
+        (next, [indexNum]) => Math.max(next, indexNum + 1),
+        0,
+      );
     }
 
     export async function getAllBlock(): Promise<model.BlockEntry[]> {
-      const tabLength = await getTabLength();
-
-      const promiseArray: Promise<[number, string]>[] = [];
-
-      for (let i = 0; i < tabLength; i++) {
-        promiseArray.push(getSyncStorageReturnIndex(i));
-      }
-
-      const result = await Promise.all(promiseArray);
+      const blockData = await getAllBlockData();
       const entries = await Promise.all(
-        result
-          // keyが存在しないindexは削除済みのブロックなので一覧に含めない。
-          // 空文字列は書き込みが壊れた形跡なのでBrokenBlockとして扱う
-          .filter((obj) => obj[1] != null)
-          .map((arr) => inflateEntry(arr[1], arr[0])),
+        // 空文字列は書き込みが壊れた形跡なのでBrokenBlockとして扱う
+        blockData.map(([indexNum, json]) => inflateEntry(json, indexNum)),
       );
       return entries.toSorted(blockService.compareBlockEntry);
     }

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -89,7 +89,11 @@ describe('App', (): void => {
         sync: {
           QUOTA_BYTES: 102400,
           getBytesInUse: (): Promise<number> => Promise.resolve(0),
-          get: (keys: string[]): Promise<{ [key: string]: string }> => {
+          // 実際のchrome.storage.syncと同じく、nullを渡されたら全キーを返す
+          get: (keys: string[] | null): Promise<{ [key: string]: string }> => {
+            if (keys == null) {
+              return Promise.resolve({ ...syncData });
+            }
             const res: { [key: string]: string } = {};
             for (const key of keys) {
               const value = syncData[key];
@@ -1057,6 +1061,37 @@ describe('App', (): void => {
     } finally {
       consoleErrorSpy.mockRestore();
     }
+  });
+
+  // t_lenが壊れているとgetTabLengthの例外がreloadの.catchへ落ち、
+  // blocksがnullのままMainがマウントされず一覧が丸ごと消えていた(#229)
+  test('t_lenが壊れていても一覧が表示される', async (): Promise<void> => {
+    getAllBlockSpy.mockRestore();
+    syncData['t_len'] = 'broken';
+    syncData['td_0'] =
+      '{"v":2,"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"title-a"}]}';
+    syncData['td_1'] =
+      '{"v":2,"created_at":1640000000000,"tabs":[{"url":"https://example.com/b","title":"title-b"}]}';
+
+    await mount();
+
+    expect(container.textContent).toContain('title-a');
+    expect(container.textContent).toContain('title-b');
+  });
+
+  // 書き込み失敗でt_lenの外側に取り残されたブロックも一覧に出す(#232の事後回収)
+  test('t_lenの外側に保存されたブロックも一覧に表示される', async (): Promise<void> => {
+    getAllBlockSpy.mockRestore();
+    syncData['t_len'] = '1';
+    syncData['td_0'] =
+      '{"v":2,"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"title-a"}]}';
+    syncData['td_5'] =
+      '{"v":2,"created_at":1640000000000,"tabs":[{"url":"https://example.com/orphan","title":"title-orphan"}]}';
+
+    await mount();
+
+    expect(container.textContent).toContain('title-a');
+    expect(container.textContent).toContain('title-orphan');
   });
 
   test('壊れたタブを削除しても同じブロックの正常なタブは残る', async (): Promise<void> => {


### PR DESCRIPTION
## 概要

`t_len` が壊れているとタブ一覧が完全に表示されなくなる問題を直す。

`t_len` は「件数」ではなく**採番カウンタ**で、`removeBlock` でも減らず、書き込み失敗や旧形式で壊れうる。にもかかわらず `getAllBlock()` がこれを走査範囲に使っていたため、数値化できない値になると `getTabLength()` の例外が `app.tsx` の `reload()` の `.catch` へ落ち、`blocks` が `null` のまま `Main` がマウントされず**一覧が丸ごと消えていた**。

`t_len` を 0 にフォールバックしても結局全件が見えなくなるため、走査範囲そのものを変える。

## 変更内容

### 一覧の単一ソースを `td_N` キーの集合へ

- `getAllBlock()` を `chrome.storage.sync.get(null)` による全キー取得に切り替え、`/^td_(\d+)$/` にマッチするキーだけを拾う。**`t_len` を一切読まない**ので、壊れていても一覧は表示される
- 保存件数ぶん個別に `get` していた往復が 1 回にまとまる

### 採番もキー由来に

- `getNextBlockIndex()` を新設。保存済み index の最大値 + 1 を返すので、`t_len` が実データとずれていても既存ブロックを上書きしない
- `background.ts`（タブ保存）と `blockService.ts`（インポート）の採番をこれに差し替え

### `t_len` への書き込みは互換として維持

`storage.sync` は複数端末で共有されるため、まだ更新前のバージョンが動いている端末で一覧が欠けないよう、`setTabLength()` の呼び出しは残している。将来まとめて削除する。

## 副次的な効果

書き込み失敗で `t_len` の外側に取り残されていたブロックも一覧に出るようになる（#232 の被害の事後回収）。既存ユーザーの storage に孤児が残っていれば、更新後に見えるようになる。

## キーの検疫

`td_N` の `N` は `Number()` で index に潰すため、`tabKey(index)` で元のキーに戻らないものはブロックとして扱わない（`td_007` のような先頭ゼロ、`Number.MAX_SAFE_INTEGER` を超える桁数）。拾ってしまうと書き戻しが別のキーへ行って同じブロックが2枚に増え、元のキーは UI から削除できないまま残る。

採番側にも同じ検疫を掛けている。保存済み index が `Number.MAX_SAFE_INTEGER` だと `+1` が桁あふれして読み戻せないキーを書いてしまうので、その場合は index の単調性を諦めて空いている最小の index を使う。

### 申し送り

検疫で弾いたキー（同期経由で入りうる `td_007` など）は一覧に出ないぶん `getBytesInUse` の使用量だけを食い、**全データ削除以外に回収手段がない**。PR 前は「index 7 のカードとして出るが、書き戻すと `td_7` に増殖して `td_007` は残る」だったので今回の変更は改善だが、回収手段がない状態は残る。raw key を持つ破損カードとして出す・`removeBlock` を key ベースに広げる、といった対応は別 issue にしたい。

## テスト

- `t_len` が `broken` / 空文字列 / 負の数 / 実データより小さい・大きい / 未保存 のいずれでも全件返ること
- ブロック以外のキー（`t_len` / `error` / `td_x`）を一覧に含めないこと
- `getNextBlockIndex` が 0 件で 0、欠番をまたいで最大値 + 1、`t_len` が実データより小さくても上書きしない index を返すこと
- app レベルの回帰テスト: `t_len` が壊れていても一覧が表示される / `t_len` の外側のブロックも表示される

- 往復できないキー（`td_007` / 21桁 / `td_9007199254740992`）を一覧にも採番にも使わないこと。境界の反対側（`td_9007199254740991` は通す）も固定
- 保存データが文字列でない（`42` / `null` / `true` / オブジェクト / 配列）場合も BrokenBlock に落ち、一覧全体を reject させないこと
- index をこれ以上進められないとき、空いている最小の index を返すこと

`npm run format:check` / `npm run lint` / `npm test`（13 suites, 303 tests）すべて通過。CI も pass。

## 手動確認（未実施 / レビュー時にお願いしたい点）

DevTools から `chrome.storage.sync.set({t_len: 'broken'})` を実行 → tabs ページをリロード → 一覧が全件表示されること。`chrome.storage.sync.remove('t_len')` でも同様。

Closes #229
Refs #232
Refs #192
