### PR TITLE
ブロックへの書き込みを直列化し、書き込む直前の内容の上に載せる

### DIFF
--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -1900,3 +1900,152 @@ describe('App', (): void => {
     }
   });
 });
+
+// chrome.tabs.createを待っている間、カード内の他の操作は止まっていない。
+// クリック時のpropsを閉じ込めたまま書き戻すと、その間に消したはずの
+// ブロックやタブが復活する(#248)
+describe('App ブロックへの書き込みが重なったとき', (): void => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let getAllBlockSpy: jest.SpyInstance;
+  let setBlockSpy: jest.SpyInstance;
+  let createTabsSpy: jest.SpyInstance;
+  // タブが開き終わるタイミングを操作するため、解決を手元に持つ
+  let resolveCreateTabs: () => void;
+
+  const mount = async (): Promise<void> => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+  };
+
+  const click = async (selector: string, index = 0): Promise<void> => {
+    await act(async () => {
+      container.querySelectorAll<HTMLElement>(selector)[index]!.click();
+    });
+  };
+
+  // storageへ書かれたブロックのタブ配列。削除は空配列として現れる
+  const writtenTabs = (): (string | undefined)[][] =>
+    setBlockSpy.mock.calls.map((call) =>
+      (call[0] as model.Block).tabs.map((tab) => tab?.title),
+    );
+
+  beforeEach((): void => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    getAllBlockSpy = jest
+      .spyOn(chromeService.storage, 'getAllBlock')
+      .mockResolvedValue([
+        {
+          indexNum: 0,
+          createdAt: new Date('2021-01-02T03:04:05.678Z'),
+          tabs: [
+            { url: 'https://example.com/a', title: 'title-a' },
+            { url: 'https://example.com/b', title: 'title-b' },
+          ],
+        },
+      ]);
+    setBlockSpy = jest
+      .spyOn(chromeService.storage, 'setBlock')
+      .mockResolvedValue(undefined);
+    resolveCreateTabs = () => {};
+    createTabsSpy = jest.spyOn(chromeService.tab, 'createTabs').mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveCreateTabs = resolve;
+      }),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      runtime: {
+        getManifest: () => ({ name: 'SyncTabClipper', version: '9.9.9' }),
+      },
+      i18n: { getMessage: (key: string): string => key },
+      storage: {
+        local: {
+          set: (): Promise<void> => Promise.resolve(),
+          get: (): Promise<{ [key: string]: string }> => Promise.resolve({}),
+          remove: (): Promise<void> => Promise.resolve(),
+        },
+        sync: {
+          QUOTA_BYTES: 102400,
+          getBytesInUse: (): Promise<number> => Promise.resolve(0),
+          get: (): Promise<{ [key: string]: unknown }> => Promise.resolve({}),
+        },
+        onChanged: { addListener: jest.fn(), removeListener: jest.fn() },
+      },
+      action: { setBadgeText: jest.fn(), setBadgeBackgroundColor: jest.fn() },
+    };
+  });
+
+  afterEach((): void => {
+    act(() => root.unmount());
+    container.remove();
+    getAllBlockSpy.mockRestore();
+    setBlockSpy.mockRestore();
+    createTabsSpy.mockRestore();
+  });
+
+  // ケース1: リンクを開いている最中にブロックごと削除する。
+  // 書き戻すとremoveBlockで消したtd_0が1タブ入りで復活し、画面からは
+  // 消えて見えているのでユーザーは気付けない
+  test('リンクを開いている間にブロックを削除したら書き戻さない', async (): Promise<void> => {
+    await mount();
+
+    await click('.tab_link');
+    await click('.all_tab_delete');
+    // ここまでで削除の書き込み（空配列）だけが起きている
+    expect(writtenTabs()).toStrictEqual([[]]);
+
+    await act(async () => {
+      resolveCreateTabs();
+    });
+
+    // 開き終わっても、消えたブロックへは書き戻さない
+    expect(writtenTabs()).toStrictEqual([[]]);
+  });
+
+  // ケース2: 2件の削除が重なる。ブロックを丸ごと書き戻すため、
+  // 後から着地した側が相手の削除を打ち消し、消したタブが復活していた
+  test('タブの削除が重なっても両方の削除が残る', async (): Promise<void> => {
+    createTabsSpy.mockResolvedValue(undefined);
+    // 1件目の書き込みを飛行中のままにして、着地する前に2件目を始めさせる
+    let resolveFirstWrite: () => void = () => {};
+    setBlockSpy.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirstWrite = () => resolve();
+        }),
+    );
+    await mount();
+
+    // 1件目の書き込みが着地していないので、一覧はまだ2件のまま表示される
+    await click('.tab_close', 0);
+    await click('.tab_close', 1);
+    await act(async () => {
+      resolveFirstWrite();
+    });
+
+    // 2件目は1件目の結果の上に積まれる。
+    // クリック時のpropsから書き戻すと、2件目がtitle-aを復活させる
+    expect(writtenTabs()).toStrictEqual([['title-b'], []]);
+  });
+
+  // 待っている間に並びが変わると、indexで指した書き戻しは
+  // 開いてもいないタブを消してしまう
+  test('待っている間に並びが変わっても開いたタブだけを消す', async (): Promise<void> => {
+    await mount();
+
+    // 2件目のリンクを開く。開き終わるまでの間に1件目を削除して並びをずらす
+    await click('.tab_link', 1);
+    createTabsSpy.mockResolvedValue(undefined);
+    await click('.tab_close', 0);
+    await act(async () => {
+      resolveCreateTabs();
+    });
+
+    // 1件目の削除に続いて、開いたタブ（title-b）だけが消える
+    expect(writtenTabs()).toStrictEqual([['title-b'], []]);
+  });
+});

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -1912,6 +1912,12 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
   let createTabsSpy: jest.SpyInstance;
   // タブが開き終わるタイミングを操作するため、解決を手元に持つ
   let resolveCreateTabs: () => void;
+  let onChangedListeners: Array<
+    (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string,
+    ) => void
+  >;
 
   const mount = async (): Promise<void> => {
     await act(async () => {
@@ -1932,9 +1938,21 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
       (call[0] as model.Block).tabs.map((tab) => tab?.title),
     );
 
+  // storage.syncの変更をChromeと同様に購読側へ通知する
+  const notifySync = async (changes: {
+    [key: string]: chrome.storage.StorageChange;
+  }): Promise<void> => {
+    await act(async () => {
+      for (const listener of onChangedListeners) {
+        listener(changes, 'sync');
+      }
+    });
+  };
+
   beforeEach((): void => {
     container = document.createElement('div');
     document.body.appendChild(container);
+    onChangedListeners = [];
     getAllBlockSpy = jest
       .spyOn(chromeService.storage, 'getAllBlock')
       .mockResolvedValue([
@@ -1973,7 +1991,17 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
           getBytesInUse: (): Promise<number> => Promise.resolve(0),
           get: (): Promise<{ [key: string]: unknown }> => Promise.resolve({}),
         },
-        onChanged: { addListener: jest.fn(), removeListener: jest.fn() },
+        onChanged: {
+          addListener: (
+            listener: (
+              changes: { [key: string]: chrome.storage.StorageChange },
+              areaName: string,
+            ) => void,
+          ): void => {
+            onChangedListeners.push(listener);
+          },
+          removeListener: jest.fn(),
+        },
       },
       action: { setBadgeText: jest.fn(), setBadgeBackgroundColor: jest.fn() },
     };
@@ -2192,6 +2220,114 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
       allClearSpy.mockRestore();
       confirmSpy.mockRestore();
       alertSpy.mockRestore();
+    }
+  });
+
+  // allClearが着地するまでblocksRefは削除前のままなので、この間に始まった
+  // 書き込みは「消えたブロックには書き戻さない」ガードをすり抜ける
+  test('全データ削除の最中に始まった書き込みは書き戻さない', async (): Promise<void> => {
+    createTabsSpy.mockResolvedValue(undefined);
+    let resolveAllClear: () => void = () => {};
+    const allClearSpy = jest
+      .spyOn(chromeService.storage, 'allClear')
+      .mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveAllClear = () => resolve();
+        }),
+      );
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    const alertSpy = jest
+      .spyOn(window, 'alert')
+      .mockImplementation(() => undefined);
+
+    try {
+      await mount();
+
+      // 飛行中の書き込みはないのでallClearはすぐ始まる
+      await click('#all_clear');
+      expect(allClearSpy).toHaveBeenCalledTimes(1);
+
+      // allClearの着地前にカード内のタブを消す
+      await click('.tab_close', 0);
+      expect(setBlockSpy).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveAllClear();
+      });
+
+      expect(setBlockSpy).not.toHaveBeenCalled();
+    } finally {
+      allClearSpy.mockRestore();
+      confirmSpy.mockRestore();
+      alertSpy.mockRestore();
+    }
+  });
+
+  // 開いたタブが待っている間に全部消えていたら、書き戻す内容が変わらない。
+  // storage.syncの書き込みクォータを空振りで消費するだけになる
+  test('開いたタブが先に消えていたら書き戻さない', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([
+      {
+        indexNum: 0,
+        createdAt: new Date('2021-01-02T03:04:05.678Z'),
+        // 壊れたタブは開けないので、ブロックごと消えずに残る
+        tabs: [
+          { url: 'https://example.com/a', title: 'title-a' },
+          null as unknown as model.Tab,
+        ],
+      },
+    ]);
+    await mount();
+
+    // 「すべてのリンクを開く」の書き戻しを待たせている間にtitle-aを消す
+    await click('.all_tab_link');
+    createTabsSpy.mockResolvedValue(undefined);
+    await click('.tab_close', 0);
+    await act(async () => {
+      resolveCreateTabs();
+    });
+
+    // 消えるのはtitle-aの1回だけ。開いた分の書き戻しは行わない
+    expect(writtenTabs()).toStrictEqual([[undefined]]);
+  });
+
+  // 壊れたブロックの削除も同じキューに乗せないと、飛行中の書き込みが
+  // あとから着地して、消したブロックがstorageに戻る
+  test('壊れたブロックの削除は飛行中の書き込みの後に行う', async (): Promise<void> => {
+    createTabsSpy.mockResolvedValue(undefined);
+    let resolveWrite: () => void = () => {};
+    setBlockSpy.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = () => resolve();
+        }),
+    );
+    const removeBlockSpy = jest
+      .spyOn(chromeService.storage, 'removeBlock')
+      .mockResolvedValue(undefined);
+
+    try {
+      await mount();
+
+      // タブの削除が飛行中のまま、読み直しで同じブロックが
+      // 復元できないものに変わる（他端末が壊れたデータを書いた場合など）
+      await click('.tab_close', 0);
+      getAllBlockSpy.mockResolvedValue([
+        { indexNum: 0, broken: true, unsupported: false },
+      ]);
+      await notifySync({ td_0: { newValue: 'broken' } });
+
+      await click('.broken_block_delete');
+      // 飛行中の書き込みが着地するまで消さない
+      expect(removeBlockSpy).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveWrite();
+      });
+
+      expect(removeBlockSpy).toHaveBeenCalledWith(0);
+    } finally {
+      removeBlockSpy.mockRestore();
     }
   });
 

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -2032,6 +2032,169 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
     expect(writtenTabs()).toStrictEqual([['title-b'], []]);
   });
 
+  // 3件以上積んだときも必ず直前の結果の上に載せる。cleanupが最後尾以外を
+  // 消すと、あとから積んだ書き込みが並行して打ち消し合う
+  test('同じブロックへ3件積んでも順に直前の結果の上に載せる', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([
+      {
+        indexNum: 0,
+        createdAt: new Date('2021-01-02T03:04:05.678Z'),
+        tabs: [
+          { url: 'https://example.com/a', title: 'title-a' },
+          { url: 'https://example.com/b', title: 'title-b' },
+          { url: 'https://example.com/c', title: 'title-c' },
+        ],
+      },
+    ]);
+    createTabsSpy.mockResolvedValue(undefined);
+    const resolvers: (() => void)[] = [];
+    setBlockSpy.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(() => resolve());
+        }),
+    );
+    await mount();
+
+    // 3件とも着地を待たずに押す
+    await click('.tab_close', 0);
+    await click('.tab_close', 1);
+    await click('.tab_close', 2);
+    // 1件目だけが走っており、2・3件目は積まれて待っている
+    expect(writtenTabs()).toStrictEqual([['title-b', 'title-c']]);
+
+    await act(async () => {
+      resolvers[0]!();
+    });
+    await act(async () => {
+      resolvers[1]!();
+    });
+    await act(async () => {
+      resolvers[2]!();
+    });
+
+    expect(writtenTabs()).toStrictEqual([
+      ['title-b', 'title-c'],
+      ['title-c'],
+      [],
+    ]);
+  });
+
+  // 先に積んだ書き込みが着地したあとに積む場合。cleanupが最後尾かどうかを
+  // 見ないと、まだ飛行中の2件目を残したままキューが空と見なされ、
+  // 3件目が並行して走って2件目の削除を打ち消す
+  test('先の書き込みが着地したあとに積んでも並行させない', async (): Promise<void> => {
+    getAllBlockSpy.mockResolvedValue([
+      {
+        indexNum: 0,
+        createdAt: new Date('2021-01-02T03:04:05.678Z'),
+        tabs: [
+          { url: 'https://example.com/a', title: 'title-a' },
+          { url: 'https://example.com/b', title: 'title-b' },
+          { url: 'https://example.com/c', title: 'title-c' },
+        ],
+      },
+    ]);
+    createTabsSpy.mockResolvedValue(undefined);
+    const resolvers: (() => void)[] = [];
+    setBlockSpy.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(() => resolve());
+        }),
+    );
+    await mount();
+
+    await click('.tab_close', 0);
+    await click('.tab_close', 1);
+    // 1件目だけを着地させる。2件目はまだ飛行中
+    await act(async () => {
+      resolvers[0]!();
+    });
+
+    // 一覧は[title-b, title-c]になっている。ここでtitle-cを消す
+    await click('.tab_close', 1);
+    await act(async () => {
+      resolvers[1]!();
+    });
+    await act(async () => {
+      resolvers[2]!();
+    });
+
+    expect(writtenTabs()).toStrictEqual([
+      ['title-b', 'title-c'],
+      ['title-c'],
+      [],
+    ]);
+  });
+
+  // 失敗した書き込みでキューを止めると、以降そのブロックを操作できなくなる
+  test('直前の書き込みが失敗しても次の書き込みは走る', async (): Promise<void> => {
+    createTabsSpy.mockResolvedValue(undefined);
+    let rejectFirstWrite: () => void = () => {};
+    setBlockSpy.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectFirstWrite = () => reject(new Error('quota exceeded'));
+        }),
+    );
+    await mount();
+
+    await click('.tab_close', 0);
+    await click('.tab_close', 1);
+    await act(async () => {
+      rejectFirstWrite();
+    });
+
+    // 1件目が失敗しても2件目は走る。1件目は反映されていないので、
+    // 2件目は2件のままの一覧からtitle-bだけを消す
+    expect(writtenTabs()).toStrictEqual([['title-b'], ['title-a']]);
+  });
+
+  // updateBlockのガードは書き込みを始める前にしか効かない。
+  // 飛行中の書き込みを待たずにstorageを空にすると、あとから着地した
+  // 書き込みが消したはずのブロックを書き戻し、画面が0件のまま復活する
+  test('全データ削除は飛行中の書き込みが着地してから消す', async (): Promise<void> => {
+    createTabsSpy.mockResolvedValue(undefined);
+    let resolveWrite: () => void = () => {};
+    setBlockSpy.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = () => resolve();
+        }),
+    );
+    const allClearSpy = jest
+      .spyOn(chromeService.storage, 'allClear')
+      .mockResolvedValue(undefined);
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    const alertSpy = jest
+      .spyOn(window, 'alert')
+      .mockImplementation(() => undefined);
+
+    try {
+      await mount();
+
+      // タブの削除が飛行中のまま全データ削除を押す
+      await click('.tab_close', 0);
+      await click('#all_clear');
+
+      // 飛行中の書き込みが着地するまでstorageは空にしない
+      expect(allClearSpy).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveWrite();
+      });
+
+      expect(allClearSpy).toHaveBeenCalledTimes(1);
+      // 空にしたあとに書き戻しは起きない
+      expect(setBlockSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      allClearSpy.mockRestore();
+      confirmSpy.mockRestore();
+      alertSpy.mockRestore();
+    }
+  });
+
   // 待っている間に並びが変わると、indexで指した書き戻しは
   // 開いてもいないタブを消してしまう
   test('待っている間に並びが変わっても開いたタブだけを消す', async (): Promise<void> => {

--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -105,6 +105,51 @@ const App: React.FC = () => {
   // React.memo化したBlockの再レンダリングを防ぐため参照を安定させる。
   // 失敗はerrorLogに記録したうえで、呼び出し側が結果に応じてUIを制御できる
   // （編集モーダルを閉じない等）よう再throwする
+  const enqueueWrite = useCallback(
+    (indexNum: number, job: () => Promise<void>): Promise<void> => {
+      const start = (): Promise<void> => {
+        try {
+          return job();
+        } catch (error) {
+          // 同期の例外のまま抜けると、キューの繋ぎ方によって
+          // 呼び出し側の受け方が変わる
+          return Promise.reject(error);
+        }
+      };
+      const inFlight = writeQueues.current.get(indexNum);
+      // 飛行中の書き込みがなければその場で始める。待たせるだけの
+      // マイクロタスクを挟むと、書き込み中の表示（tabsWriting）が
+      // 独立したレンダリングとして一瞬見えてしまう。
+      // 直前の書き込みの成否に関わらず次を走らせるのは、失敗した書き込みで
+      // キューを止めると以降そのブロックを操作できなくなるため
+      const queued =
+        inFlight == null
+          ? start()
+          : inFlight.catch(() => undefined).then(start);
+      // 自分が最後尾のときだけ後始末する。あとから積まれていたら
+      // そちらが末尾なので消さない
+      const cleanup = (): void => {
+        if (writeQueues.current.get(indexNum) === queued) {
+          writeQueues.current.delete(indexNum);
+        }
+      };
+      writeQueues.current.set(indexNum, queued);
+      queued.then(cleanup, cleanup);
+      return queued;
+    },
+    [],
+  );
+
+  // 飛行中の書き込みがすべて着地するまで待つ。storageを丸ごと消す前に
+  // 待たないと、あとから着地した書き込みが消したはずのブロックを書き戻す
+  // （updateBlockのガードは書き込みを始める前にしか効かない）。
+  // 待っている間に積まれた書き込みも待つ
+  const waitForWrites = useCallback(async (): Promise<void> => {
+    while (writeQueues.current.size > 0) {
+      await Promise.allSettled([...writeQueues.current.values()]);
+    }
+  }, []);
+
   const updateBlock = useCallback(
     (
       indexNum: number,
@@ -116,6 +161,8 @@ const App: React.FC = () => {
         );
         // 待っている間に消えた／壊れたと分かったブロックには書き戻さない。
         // ここで書くと、削除済みのブロックがstorageに戻って復活する
+        // 呼び出し側からは成功として見える。書けなかったことを伝えても、
+        // 対象のカードはすでに一覧から外れていて見せる先がない
         if (current == null || blockService.isBrokenBlock(current)) {
           return Promise.resolve();
         }
@@ -153,47 +200,31 @@ const App: React.FC = () => {
           });
       };
 
-      const inFlight = writeQueues.current.get(indexNum);
-      // 飛行中の書き込みがなければその場で始める。待たせるだけの
-      // マイクロタスクを挟むと、書き込み中の表示（tabsWriting）が
-      // 独立したレンダリングとして一瞬見えてしまう。
-      // 直前の書き込みの成否に関わらず次を走らせるのは、失敗した書き込みで
-      // キューを止めると以降そのブロックを操作できなくなるため
-      const queued =
-        inFlight == null ? run() : inFlight.catch(() => undefined).then(run);
-      // 自分が最後尾のときだけ後始末する。あとから積まれていたら
-      // そちらが末尾なので消さない
-      const cleanup = (): void => {
-        if (writeQueues.current.get(indexNum) === queued) {
-          writeQueues.current.delete(indexNum);
-        }
-      };
-      writeQueues.current.set(indexNum, queued);
-      queued.then(cleanup, cleanup);
-      return queued;
+      return enqueueWrite(indexNum, run);
     },
-    [applyBlocks],
+    [applyBlocks, enqueueWrite],
   );
 
   // 復元・描画できなかったブロックはmodel.Blockを作れないため、
   // indexNumだけを渡してstorageから削除する
   const deleteBrokenBlock = useCallback(
     (indexNum: number) => {
-      chromeService.storage
-        .removeBlock(indexNum)
-        .then(() => {
+      // 同じブロックへの書き込みと並行させない。飛行中の書き込みが
+      // あとから着地すると、削除したブロックがstorageに戻る
+      enqueueWrite(indexNum, () =>
+        chromeService.storage.removeBlock(indexNum).then(() => {
           setFromStorage(false);
           const prevBlocks = blocksRef.current;
           if (prevBlocks == null) {
             return;
           }
           applyBlocks(prevBlocks.filter((block) => block.indexNum != indexNum));
-        })
-        .catch((error) => {
-          chromeService.errorLog.set(error).catch(console.error);
-        });
+        }),
+      ).catch((error) => {
+        chromeService.errorLog.set(error).catch(console.error);
+      });
     },
-    [applyBlocks],
+    [applyBlocks, enqueueWrite],
   );
 
   // 一覧の並びはstorageから読み込んだ時点でも整えているが、スターの付け外しは
@@ -209,11 +240,13 @@ const App: React.FC = () => {
   // 完了通知（alert）はUIを持つSideBar側で行うためPromiseを返す
   const deleteAllBlocks = useCallback(
     (): Promise<void> =>
-      chromeService.storage.allClear().then(() => {
-        setFromStorage(false);
-        applyBlocks([]);
-      }),
-    [applyBlocks],
+      waitForWrites().then(() =>
+        chromeService.storage.allClear().then(() => {
+          setFromStorage(false);
+          applyBlocks([]);
+        }),
+      ),
+    [applyBlocks, waitForWrites],
   );
 
   return (

--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -31,6 +31,16 @@ const App: React.FC = () => {
   const reloading = useRef(false);
   const reloadQueued = useRef(false);
 
+  // 書き込み時点の一覧を読むための写し。書き込みの直列化(#248)では
+  // 次の書き込みが再レンダリングを待たずに走るため、stateだけを見ると
+  // 直前の書き込みが反映される前の内容の上に書いてしまう。
+  // レンダリング時ではなくstateを進めるのと同じタイミングで進める
+  const blocksRef = useRef<model.BlockEntry[] | null>(null);
+  const applyBlocks = useCallback((next: model.BlockEntry[] | null): void => {
+    blocksRef.current = next;
+    setBlocks(next);
+  }, []);
+
   const reload = useCallback((): void => {
     if (reloading.current) {
       reloadQueued.current = true;
@@ -41,7 +51,7 @@ const App: React.FC = () => {
       chromeService.storage
         .getAllBlock()
         .then((entries) => {
-          setBlocks(entries);
+          applyBlocks(entries);
           setFromStorage(true);
         })
         .catch((error) => {
@@ -58,7 +68,7 @@ const App: React.FC = () => {
         });
     };
     run();
-  }, []);
+  }, [applyBlocks]);
 
   useEffect(() => {
     reload();
@@ -81,57 +91,110 @@ const App: React.FC = () => {
     return () => chrome.storage.onChanged.removeListener(onChanged);
   }, [reload]);
 
+  // ブロックごとの書き込みキュー。updateBlockはブロックを丸ごと書き戻すため、
+  // 同じブロックへの書き込みが並行すると後から着地した側が相手の変更を
+  // 打ち消す。indexNumごとに直列化して、必ず直前の結果の上に積む
+  const writeQueues = useRef(new Map<number, Promise<void>>());
+
   // ブロックの変更をstorageへ永続化し、成功時のみstateへ反映する。
+  // 更新内容ではなく更新関数を受け取るのは、chrome.tabs.createを待つ間に
+  // 一覧が変わっていても、書き込む直前の内容の上に変更を載せるため。
+  // クリック時のpropsを閉じ込めたまま書き戻すと、その間に消したはずの
+  // ブロックやタブが復活する。
   // タブが空になったブロックはstorage側で削除されるため一覧からも除く。
   // React.memo化したBlockの再レンダリングを防ぐため参照を安定させる。
   // 失敗はerrorLogに記録したうえで、呼び出し側が結果に応じてUIを制御できる
   // （編集モーダルを閉じない等）よう再throwする
   const updateBlock = useCallback(
-    (newBlock: model.Block): Promise<void> =>
-      chromeService.storage
-        .setBlock(newBlock)
-        .then(() => {
-          // この画面の操作による更新なので、並び替わったカードの移動は見せる
-          setFromStorage(false);
-          setBlocks((prevBlocks) => {
+    (
+      indexNum: number,
+      update: (current: model.Block) => model.Block,
+    ): Promise<void> => {
+      const run = (): Promise<void> => {
+        const current = blocksRef.current?.find(
+          (block) => block.indexNum == indexNum,
+        );
+        // 待っている間に消えた／壊れたと分かったブロックには書き戻さない。
+        // ここで書くと、削除済みのブロックがstorageに戻って復活する
+        if (current == null || blockService.isBrokenBlock(current)) {
+          return Promise.resolve();
+        }
+        let newBlock: model.Block;
+        try {
+          newBlock = update(current);
+        } catch (error) {
+          // 更新関数は「もう書くべきではない」と分かったときに投げる
+          // （ロックされた・編集対象が失われた）。同期の例外のまま
+          // 抜けるとキューの繋ぎ方によって呼び出し側の受け方が変わる
+          return Promise.reject(error);
+        }
+        return chromeService.storage
+          .setBlock(newBlock)
+          .then(() => {
+            // この画面の操作による更新なので、並び替わったカードの移動は見せる
+            setFromStorage(false);
+            const prevBlocks = blocksRef.current;
             if (prevBlocks == null) {
-              return prevBlocks;
+              return;
             }
-            if (newBlock.tabs.length <= 0) {
-              return prevBlocks.filter(
-                (block) => block.indexNum != newBlock.indexNum,
-              );
-            }
-            return prevBlocks.map((block) =>
-              block.indexNum == newBlock.indexNum ? newBlock : block,
+            applyBlocks(
+              newBlock.tabs.length <= 0
+                ? prevBlocks.filter(
+                    (block) => block.indexNum != newBlock.indexNum,
+                  )
+                : prevBlocks.map((block) =>
+                    block.indexNum == newBlock.indexNum ? newBlock : block,
+                  ),
             );
+          })
+          .catch((error) => {
+            chromeService.errorLog.set(error).catch(console.error);
+            throw error;
           });
-        })
-        .catch((error) => {
-          chromeService.errorLog.set(error).catch(console.error);
-          throw error;
-        }),
-    [],
+      };
+
+      const inFlight = writeQueues.current.get(indexNum);
+      // 飛行中の書き込みがなければその場で始める。待たせるだけの
+      // マイクロタスクを挟むと、書き込み中の表示（tabsWriting）が
+      // 独立したレンダリングとして一瞬見えてしまう。
+      // 直前の書き込みの成否に関わらず次を走らせるのは、失敗した書き込みで
+      // キューを止めると以降そのブロックを操作できなくなるため
+      const queued =
+        inFlight == null ? run() : inFlight.catch(() => undefined).then(run);
+      // 自分が最後尾のときだけ後始末する。あとから積まれていたら
+      // そちらが末尾なので消さない
+      const cleanup = (): void => {
+        if (writeQueues.current.get(indexNum) === queued) {
+          writeQueues.current.delete(indexNum);
+        }
+      };
+      writeQueues.current.set(indexNum, queued);
+      queued.then(cleanup, cleanup);
+      return queued;
+    },
+    [applyBlocks],
   );
 
   // 復元・描画できなかったブロックはmodel.Blockを作れないため、
   // indexNumだけを渡してstorageから削除する
-  const deleteBrokenBlock = useCallback((indexNum: number) => {
-    chromeService.storage
-      .removeBlock(indexNum)
-      .then(() => {
-        setFromStorage(false);
-        setBlocks((prevBlocks) => {
+  const deleteBrokenBlock = useCallback(
+    (indexNum: number) => {
+      chromeService.storage
+        .removeBlock(indexNum)
+        .then(() => {
+          setFromStorage(false);
+          const prevBlocks = blocksRef.current;
           if (prevBlocks == null) {
-            return prevBlocks;
+            return;
           }
-          return prevBlocks.filter((block) => block.indexNum != indexNum);
+          applyBlocks(prevBlocks.filter((block) => block.indexNum != indexNum));
+        })
+        .catch((error) => {
+          chromeService.errorLog.set(error).catch(console.error);
         });
-      })
-      .catch((error) => {
-        chromeService.errorLog.set(error).catch(console.error);
-      });
-  }, []);
+    },
+    [applyBlocks],
+  );
 
   // 一覧の並びはstorageから読み込んだ時点でも整えているが、スターの付け外しは
   // 並び順そのものを変えるため、state側でも同じ規則で並べ直す。
@@ -148,9 +211,9 @@ const App: React.FC = () => {
     (): Promise<void> =>
       chromeService.storage.allClear().then(() => {
         setFromStorage(false);
-        setBlocks([]);
+        applyBlocks([]);
       }),
-    [],
+    [applyBlocks],
   );
 
   return (

--- a/src/js/components/app.tsx
+++ b/src/js/components/app.tsx
@@ -96,6 +96,12 @@ const App: React.FC = () => {
   // 打ち消す。indexNumごとに直列化して、必ず直前の結果の上に積む
   const writeQueues = useRef(new Map<number, Promise<void>>());
 
+  // 全データ削除の最中かどうか。allClearが着地するまでblocksRefは削除前の
+  // ままなので、この間に始まった書き込みはupdateBlockの
+  // 「消えたブロックには書き戻さない」ガードをすり抜けて、
+  // 消したはずのブロックをstorageへ戻してしまう
+  const clearingAll = useRef(false);
+
   // ブロックの変更をstorageへ永続化し、成功時のみstateへ反映する。
   // 更新内容ではなく更新関数を受け取るのは、chrome.tabs.createを待つ間に
   // 一覧が変わっていても、書き込む直前の内容の上に変更を載せるため。
@@ -108,6 +114,10 @@ const App: React.FC = () => {
   const enqueueWrite = useCallback(
     (indexNum: number, job: () => Promise<void>): Promise<void> => {
       const start = (): Promise<void> => {
+        // これから消える一覧へ書いても意味がないので、書かずに解決する
+        if (clearingAll.current) {
+          return Promise.resolve();
+        }
         try {
           return job();
         } catch (error) {
@@ -139,16 +149,6 @@ const App: React.FC = () => {
     },
     [],
   );
-
-  // 飛行中の書き込みがすべて着地するまで待つ。storageを丸ごと消す前に
-  // 待たないと、あとから着地した書き込みが消したはずのブロックを書き戻す
-  // （updateBlockのガードは書き込みを始める前にしか効かない）。
-  // 待っている間に積まれた書き込みも待つ
-  const waitForWrites = useCallback(async (): Promise<void> => {
-    while (writeQueues.current.size > 0) {
-      await Promise.allSettled([...writeQueues.current.values()]);
-    }
-  }, []);
 
   const updateBlock = useCallback(
     (
@@ -238,16 +238,21 @@ const App: React.FC = () => {
 
   // 全データ削除をstorageへ反映し、成功時のみ一覧を空にする。
   // 完了通知（alert）はUIを持つSideBar側で行うためPromiseを返す
-  const deleteAllBlocks = useCallback(
-    (): Promise<void> =>
-      waitForWrites().then(() =>
-        chromeService.storage.allClear().then(() => {
-          setFromStorage(false);
-          applyBlocks([]);
-        }),
-      ),
-    [applyBlocks, waitForWrites],
-  );
+  const deleteAllBlocks = useCallback((): Promise<void> => {
+    // これ以降に積まれる書き込みはclearingAllで止まるので、
+    // いま飛行中のものだけを待てばよい。待たずに消すと、あとから着地した
+    // 書き込みが消したはずのブロックをstorageへ戻す
+    clearingAll.current = true;
+    return Promise.allSettled([...writeQueues.current.values()])
+      .then(() => chromeService.storage.allClear())
+      .then(() => {
+        setFromStorage(false);
+        applyBlocks([]);
+      })
+      .finally(() => {
+        clearingAll.current = false;
+      });
+  }, [applyBlocks]);
 
   return (
     <div className="uk-container">

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -22,9 +22,21 @@ type UpdateBlock = (
 
 let renderedBlock: model.Block;
 
-// updateBlockに渡された更新関数を適用して、storageへ書かれる内容を得る
-const savedBlock = (updateBlock: jest.Mock, callIndex = 0): model.Block =>
-  updateBlock.mock.calls[callIndex]![1](renderedBlock) as model.Block;
+// updateBlockに渡された更新関数を適用して、storageへ書かれる内容を得る。
+// currentを省いたときはレンダリングしたブロックを現在の内容として扱う。
+// 「クリック時のpropsではなく書き込む直前の内容に載せる」ことを確かめる
+// テストでは、propsとは別の内容をcurrentとして渡す
+const savedBlock = (
+  updateBlock: jest.Mock,
+  options: { current?: model.Block; callIndex?: number } = {},
+): model.Block =>
+  updateBlock.mock.calls[options.callIndex ?? 0]![1](
+    options.current ?? renderedBlock,
+  ) as model.Block;
+
+// updateBlockに渡されたindexNum
+const savedIndexNum = (updateBlock: jest.Mock, callIndex = 0): number =>
+  updateBlock.mock.calls[callIndex]![0] as number;
 
 describe('Block', (): void => {
   let container: HTMLDivElement;
@@ -1683,5 +1695,228 @@ describe('Block 落ちたタブの表示が読み直しで戻るか', (): void =
     expect(consoleErrorSpy.mock.calls.length).toBeLessThanOrEqual(
       perAttempt * 3,
     );
+  });
+});
+
+// この PR の核心は「クリック時のpropsではなく、書き込む直前の内容(current)に
+// 変更を載せる」こと。propsと同じcurrentを渡すテストでは両者を区別できないので、
+// ここではpropsとずれたcurrentを渡して確かめる(#248)
+describe('Block 書き込む直前に内容が変わっていたとき', (): void => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  // 画面に見えている内容
+  const shownBlock: model.Block = {
+    indexNum: 3,
+    createdAt: new Date('2021-01-02T03:04:05.678Z'),
+    tabs: [
+      { url: 'https://example.com/a', title: 'title-a' },
+      { url: 'https://example.com/b', title: 'title-b' },
+    ],
+    title: '見えている名前',
+  };
+
+  const mount = async (updateBlock: UpdateBlock): Promise<void> => {
+    renderedBlock = shownBlock;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
+    });
+  };
+
+  const click = async (selector: string, index = 0): Promise<void> => {
+    await act(async () => {
+      container.querySelectorAll<HTMLElement>(selector)[index]!.click();
+    });
+  };
+
+  beforeEach((): void => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      i18n: { getMessage: (key: string): string => key },
+    };
+  });
+
+  afterEach((): void => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  test('どのブロックへの書き込みかをindexNumで伝える', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    await click('.tab_close', 0);
+
+    expect(savedIndexNum(updateBlock)).toBe(3);
+  });
+
+  // タブを消すだけの導線でも、待っている間に他端末で変わった名前を
+  // クリック時のものへ巻き戻してはいけない
+  test('タブの削除は書き込む直前の名前を引き継ぐ', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    await click('.tab_close', 0);
+
+    expect(
+      savedBlock(updateBlock, {
+        current: { ...shownBlock, title: '書き込む直前の名前' },
+      }),
+    ).toStrictEqual({
+      ...shownBlock,
+      tabs: [{ url: 'https://example.com/b', title: 'title-b' }],
+      title: '書き込む直前の名前',
+    });
+  });
+
+  test('名前の保存は書き込む直前のタブを引き継ぐ', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    await act(async () => {
+      container.querySelector<HTMLElement>('.block-title-edit')!.click();
+    });
+    const input =
+      container.querySelector<HTMLInputElement>('.block-title-input')!;
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    )!.set!;
+    await act(async () => {
+      setter.call(input, '新しい名前');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      container.querySelector<HTMLElement>('.block-title-save')!.click();
+    });
+
+    const currentTabs = [{ url: 'https://example.com/c', title: 'title-c' }];
+    expect(
+      savedBlock(updateBlock, {
+        current: { ...shownBlock, tabs: currentTabs },
+      }),
+    ).toStrictEqual({
+      ...shownBlock,
+      tabs: currentTabs,
+      title: '新しい名前',
+    });
+  });
+
+  test('ロックの切り替えは書き込む直前のタブを引き継ぐ', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    await click('.block-lock-toggle');
+
+    const currentTabs = [{ url: 'https://example.com/c', title: 'title-c' }];
+    expect(
+      savedBlock(updateBlock, {
+        current: { ...shownBlock, tabs: currentTabs },
+      }),
+    ).toStrictEqual({ ...shownBlock, tabs: currentTabs, locked: true });
+  });
+
+  test('お気に入りの切り替えは書き込む直前のタブを引き継ぐ', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    await click('.block-star-toggle');
+
+    const currentTabs = [{ url: 'https://example.com/c', title: 'title-c' }];
+    expect(
+      savedBlock(updateBlock, {
+        current: { ...shownBlock, tabs: currentTabs },
+      }),
+    ).toStrictEqual({ ...shownBlock, tabs: currentTabs, starred: true });
+  });
+
+  // 押した時点で解除されていても、待っている間にロックされたブロックへ
+  // 書き戻すと、ロックが守るはずだったタブを消してしまう
+  test('書き込む直前にロックされていたらタブを書き換えない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    await click('.tab_close', 0);
+
+    expect(() =>
+      savedBlock(updateBlock, {
+        current: { ...shownBlock, locked: true },
+      }),
+    ).toThrow('This block is locked');
+  });
+
+  // 待っている間に他の操作で消えていたタブを消しにいくと、
+  // 同じ位置の別のタブを巻き込む
+  test('書き込む直前に対象のタブが消えていたら書き換えない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    // 1件目（title-a）の削除を押す
+    await click('.tab_close', 0);
+
+    expect(() =>
+      savedBlock(updateBlock, {
+        current: {
+          ...shownBlock,
+          tabs: [{ url: 'https://example.com/z', title: 'title-z' }],
+        },
+      }),
+    ).toThrow('tab already removed');
+  });
+
+  // 編集対象はindexで持っているため、書き込む直前の一覧で指し直さないと
+  // 別のタブを上書きする
+  test('タブの編集は書き込む直前の一覧で対象を指し直す', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    // 2件目（title-b）を編集する
+    await click('.tab_edit', 1);
+    const input = container.querySelector<HTMLInputElement>('.edit-tab-title')!;
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    )!.set!;
+    await act(async () => {
+      setter.call(input, 'renamed-b');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      container.querySelector<HTMLElement>('.edit-tab-save')!.click();
+    });
+
+    // 書き込む直前には先頭にタブが増え、title-bの位置がずれている
+    const inserted = { url: 'https://example.com/new', title: 'title-new' };
+    expect(
+      savedBlock(updateBlock, {
+        current: { ...shownBlock, tabs: [inserted, ...shownBlock.tabs] },
+      }).tabs,
+    ).toStrictEqual([
+      inserted,
+      { url: 'https://example.com/a', title: 'title-a' },
+      { url: 'https://example.com/b', title: 'renamed-b' },
+    ]);
+  });
+
+  test('書き込む直前に編集対象が消えていたら書き換えない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    await click('.tab_edit', 1);
+    await act(async () => {
+      container.querySelector<HTMLElement>('.edit-tab-save')!.click();
+    });
+
+    expect(() =>
+      savedBlock(updateBlock, {
+        current: {
+          ...shownBlock,
+          tabs: [{ url: 'https://example.com/a', title: 'title-a' }],
+        },
+      }),
+    ).toThrow('edit target lost');
   });
 });

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -12,28 +12,38 @@ import { model } from '../types/interface';
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+// Appは「更新内容」ではなく「更新関数」を受け取り、書き込む直前の一覧から
+// 現在のブロックを渡す。テストでは直近にレンダリングしたブロックを
+// そのまま現在の内容として扱う
+type UpdateBlock = (
+  indexNum: number,
+  update: (current: model.Block) => model.Block,
+) => Promise<void>;
+
+let renderedBlock: model.Block;
+
+// updateBlockに渡された更新関数を適用して、storageへ書かれる内容を得る
+const savedBlock = (updateBlock: jest.Mock, callIndex = 0): model.Block =>
+  updateBlock.mock.calls[callIndex]![1](renderedBlock) as model.Block;
+
 describe('Block', (): void => {
   let container: HTMLDivElement;
   let root: Root;
 
   const mount = async (
     tabs: model.Tab[],
-    updateBlock: (newBlock: model.Block) => Promise<void>,
+    updateBlock: UpdateBlock,
     title?: string,
   ): Promise<void> => {
+    renderedBlock = {
+      indexNum: 0,
+      createdAt: new Date('2021-01-02T03:04:05.678Z'),
+      tabs: tabs,
+      title: title,
+    };
     await act(async () => {
       root = createRoot(container);
-      root.render(
-        <Block
-          block={{
-            indexNum: 0,
-            createdAt: new Date('2021-01-02T03:04:05.678Z'),
-            tabs: tabs,
-            title: title,
-          }}
-          updateBlock={updateBlock}
-        />,
-      );
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
     });
   };
 
@@ -129,7 +139,7 @@ describe('Block', (): void => {
       container.querySelector<HTMLButtonElement>('.edit-tab-save')!.click();
     });
 
-    expect(updateBlock).toHaveBeenCalledWith(
+    expect(savedBlock(updateBlock)).toStrictEqual(
       expect.objectContaining({
         indexNum: 0,
         tabs: [
@@ -156,7 +166,7 @@ describe('Block', (): void => {
       container.querySelector<HTMLButtonElement>('.edit-tab-save')!.click();
     });
 
-    expect(updateBlock).toHaveBeenCalledWith(
+    expect(savedBlock(updateBlock)).toStrictEqual(
       expect.objectContaining({ title: '調査中のタブ' }),
     );
   });
@@ -294,7 +304,7 @@ describe('Block', (): void => {
     await typeTitle('  調査中のタブ  ');
     await saveTitle();
 
-    expect(updateBlock).toHaveBeenCalledWith({
+    expect(savedBlock(updateBlock)).toStrictEqual({
       indexNum: 0,
       createdAt: new Date('2021-01-02T03:04:05.678Z'),
       tabs: [
@@ -320,9 +330,7 @@ describe('Block', (): void => {
     await typeTitle('   ');
     await saveTitle();
 
-    expect(updateBlock).toHaveBeenCalledWith(
-      expect.objectContaining({ title: undefined }),
-    );
+    expect(savedBlock(updateBlock).title).toBeUndefined();
     expect(container.querySelector('.block-title-input')).toBeNull();
   });
 
@@ -425,7 +433,7 @@ describe('Block', (): void => {
       container.querySelectorAll<HTMLElement>('.tab_close')[0]!.click();
     });
 
-    expect(updateBlock).toHaveBeenCalledWith(
+    expect(savedBlock(updateBlock)).toStrictEqual(
       expect.objectContaining({
         tabs: [{ url: 'https://example.com/b', title: 'title-b' }],
         title: '調査中のタブ',
@@ -564,20 +572,16 @@ describe('Block タブ操作と名前の編集の排他', (): void => {
 
   const mount = async (
     tabs: model.Tab[],
-    updateBlock: (newBlock: model.Block) => Promise<void>,
+    updateBlock: UpdateBlock,
   ): Promise<void> => {
+    renderedBlock = {
+      indexNum: 0,
+      createdAt: new Date('2021-01-02T03:04:05.678Z'),
+      tabs: tabs,
+    };
     await act(async () => {
       root = createRoot(container);
-      root.render(
-        <Block
-          block={{
-            indexNum: 0,
-            createdAt: new Date('2021-01-02T03:04:05.678Z'),
-            tabs: tabs,
-          }}
-          updateBlock={updateBlock}
-        />,
-      );
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
     });
   };
 
@@ -721,24 +725,20 @@ describe('Block 編集のロック', (): void => {
 
   const mount = async (
     tabs: model.Tab[],
-    updateBlock: (newBlock: model.Block) => Promise<void>,
+    updateBlock: UpdateBlock,
     locked?: boolean,
     title?: string,
   ): Promise<void> => {
+    renderedBlock = {
+      indexNum: 0,
+      createdAt: new Date('2021-01-02T03:04:05.678Z'),
+      tabs: tabs,
+      title: title,
+      locked: locked,
+    };
     await act(async () => {
       root = createRoot(container);
-      root.render(
-        <Block
-          block={{
-            indexNum: 0,
-            createdAt: new Date('2021-01-02T03:04:05.678Z'),
-            tabs: tabs,
-            title: title,
-            locked: locked,
-          }}
-          updateBlock={updateBlock}
-        />,
-      );
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
     });
   };
 
@@ -845,7 +845,7 @@ describe('Block 編集のロック', (): void => {
 
     await clickLockToggle();
 
-    expect(updateBlock).toHaveBeenCalledWith({
+    expect(savedBlock(updateBlock)).toStrictEqual({
       indexNum: 0,
       createdAt: new Date('2021-01-02T03:04:05.678Z'),
       tabs: [{ url: 'https://example.com/a', title: 'title-a' }],
@@ -867,7 +867,7 @@ describe('Block 編集のロック', (): void => {
     // objectContainingはキーの有無を区別しないため、値そのものを確かめる
     // （lockedを持ったまま渡すとblockToJsonObjが"locked":trueを書き続ける）
     expect(updateBlock).toHaveBeenCalledTimes(1);
-    expect(updateBlock.mock.calls[0][0].locked).toBeUndefined();
+    expect(savedBlock(updateBlock).locked).toBeUndefined();
   });
 
   // App側のアラートはページ最上部に出るため、スクロール中は気付けない。
@@ -1059,22 +1059,18 @@ describe('Block お気に入り', (): void => {
   let root: Root;
 
   const mount = async (
-    updateBlock: (newBlock: model.Block) => Promise<void>,
+    updateBlock: UpdateBlock,
     block?: Partial<model.Block>,
   ): Promise<void> => {
+    renderedBlock = {
+      indexNum: 0,
+      createdAt: new Date('2021-01-02T03:04:05.678Z'),
+      tabs: [{ url: 'https://example.com/a', title: 'title-a' }],
+      ...block,
+    };
     await act(async () => {
       root = createRoot(container);
-      root.render(
-        <Block
-          block={{
-            indexNum: 0,
-            createdAt: new Date('2021-01-02T03:04:05.678Z'),
-            tabs: [{ url: 'https://example.com/a', title: 'title-a' }],
-            ...block,
-          }}
-          updateBlock={updateBlock}
-        />,
-      );
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
     });
   };
 
@@ -1106,7 +1102,7 @@ describe('Block お気に入り', (): void => {
 
     await clickStarToggle();
 
-    expect(updateBlock).toHaveBeenCalledWith({
+    expect(savedBlock(updateBlock)).toStrictEqual({
       indexNum: 0,
       createdAt: new Date('2021-01-02T03:04:05.678Z'),
       tabs: [{ url: 'https://example.com/a', title: 'title-a' }],
@@ -1125,7 +1121,7 @@ describe('Block お気に入り', (): void => {
     // objectContainingはキーの有無を区別しないため、値そのものを確かめる
     // （starredを持ったまま渡すとblockToJsonObjが"starred":trueを書き続ける）
     expect(updateBlock).toHaveBeenCalledTimes(1);
-    expect(updateBlock.mock.calls[0][0].starred).toBeUndefined();
+    expect(savedBlock(updateBlock).starred).toBeUndefined();
   });
 
   // お気に入りは並び順と装飾しか変えないため、タブを失う操作を止めるための
@@ -1143,7 +1139,7 @@ describe('Block お気に入り', (): void => {
     await clickStarToggle();
 
     expect(updateBlock).toHaveBeenCalledTimes(1);
-    expect(updateBlock.mock.calls[0][0].starred).toBe(true);
+    expect(savedBlock(updateBlock).starred).toBe(true);
   });
 
   // 色やアイコンの形だけの強調にならないよう、リボンには文字も入れる
@@ -1407,19 +1403,15 @@ describe('Block 編集中に外からタブが変わったとき', (): void => {
    */
   const render = async (
     tabs: model.Tab[],
-    updateBlock: (newBlock: model.Block) => Promise<void>,
+    updateBlock: UpdateBlock,
   ): Promise<void> => {
+    renderedBlock = {
+      indexNum: 0,
+      createdAt: new Date('2021-01-02T03:04:05.678Z'),
+      tabs: tabs,
+    };
     await act(async () => {
-      root.render(
-        <Block
-          block={{
-            indexNum: 0,
-            createdAt: new Date('2021-01-02T03:04:05.678Z'),
-            tabs: tabs,
-          }}
-          updateBlock={updateBlock}
-        />,
-      );
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
     });
   };
 
@@ -1448,7 +1440,7 @@ describe('Block 編集中に外からタブが変わったとき', (): void => {
   };
 
   const tabsOf = (updateBlock: jest.Mock): model.Tab[] =>
-    (updateBlock.mock.calls[0]![0] as model.Block).tabs;
+    savedBlock(updateBlock).tabs;
 
   beforeEach((): void => {
     container = document.createElement('div');

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -175,6 +175,11 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
           remaining.splice(at, 1);
         }
       }
+      if (remaining.length === current.tabs.length) {
+        // 待っている間に他の操作で消えていた。書き戻す必要がないので、
+        // storage.syncの書き込みクォータを無駄に使わずここで降りる
+        throw new Error('tabs already removed');
+      }
       return remaining;
     });
 
@@ -261,7 +266,10 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
       return;
     }
     // 開き終わってから書き戻すまでを1つの操作としてまとめて数える。
-    // 途中で飛行中でなくなると、その隙に名前の編集を始められてしまう
+    // 途中で飛行中でなくなると、その隙に名前の編集を始められてしまう。
+    // 1件でも開けなかったら1本も消さない（Promise.all）。
+    // 開けた分だけ消すと、失敗したタブだけが残ったのか
+    // 全部残ったのかをユーザーが見分けられない
     trackTabWrite(
       Promise.all(
         openTabs.map((tab) =>

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -12,11 +12,43 @@ import { ErrorBoundary } from './errorBoundary';
 // 持っていた場合は黙って切り捨てず、そのまま保持する
 const BLOCK_TITLE_MAX_LENGTH = 100;
 
+// タブの同一性はURLと名前で見る。indexは一覧の読み直し(#249)や
+// 同じカードへの別の操作でずれるため、chrome.tabs.createを待っている間に
+// 別のタブを指しうる。indexのまま書き戻すと無関係なタブを消してしまう。
+// 保存データが壊れているとタブ自体がnullのこともあり、その場合は
+// 内容で見分けられないので同じ「壊れたタブ」として扱う
+const sameTab = (a: model.Tab, b: model.Tab): boolean => {
+  if (a == null || b == null) {
+    return a === b;
+  }
+  return a.url === b.url && a.title === b.title;
+};
+
+// クリックした時点のタブを、書き込む直前の一覧で指し直す。
+// 同じURL・名前のタブが並んでいると内容だけでは押した行を特定できないため、
+// まずindexの位置が同じ内容のままかを確かめ、ずれていたら内容で探す
+const findTabIndex = (
+  tabs: model.Tab[],
+  target: model.Tab,
+  index: number,
+): number => {
+  if (index >= 0 && index < tabs.length && sameTab(tabs[index]!, target)) {
+    return index;
+  }
+  return tabs.findIndex((tab) => sameTab(tab, target));
+};
+
 interface BlockProps {
   block: model.Block;
   // storageへの永続化とブロック一覧stateの更新はApp側で行う。
+  // 更新内容ではなく更新関数を渡すのは、書き込む直前の内容の上に
+  // 変更を載せるため（クリック時のpropsを閉じ込めたまま書き戻すと、
+  // その間に消したはずのブロックやタブが復活する）。
   // 永続化に失敗するとrejectされる（失敗の記録はApp側で済んでいる）
-  updateBlock: (newBlock: model.Block) => Promise<void>;
+  updateBlock: (
+    indexNum: number,
+    update: (current: model.Block) => model.Block,
+  ) => Promise<void>;
 }
 
 // ブロックのstateはAppが所有し、Blockはpropsの表示と操作イベントの発火に徹する。
@@ -93,33 +125,72 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // タブ配列の差し替えをApp経由でstorageへ反映する。
   // updateBlockはブロックごと書き戻すため、タブだけを変える導線でも
   // タブ以外のフィールドを引き継がないと保存のたびに消える
-  const updateTabs = (tabs: model.Tab[]): Promise<void> => {
+  const updateTabs = (
+    nextTabs: (current: model.Block) => model.Tab[],
+  ): Promise<void> => {
     // storageへ書く唯一の入口でロックを見る。各導線側のガードだけに預けると、
     // 導線が増えたときに保護が黙って漏れる
     if (locked) {
       return Promise.reject(new Error('This block is locked'));
     }
     return trackTabWrite(
-      props.updateBlock({
-        ...block,
-        tabs: tabs,
+      props.updateBlock(block.indexNum, (current) => {
+        // 書き込む直前の内容でもロックを見る。押した時点で解除されていても、
+        // 待っている間にロックされたブロックへ書き戻すと、
+        // ロックが守るはずだったタブを消してしまう
+        if (current.locked === true) {
+          throw new Error('This block is locked');
+        }
+        return {
+          ...current,
+          tabs: nextTabs(current),
+        };
       }),
     );
   };
 
+  // 押した行のタブを取り除く。書き込む直前の一覧で指し直すため、
+  // 待っている間に並びが変わっていても無関係なタブを巻き込まない
+  const removeTabAt = (index: number): Promise<void> => {
+    const target = block.tabs[index]!;
+    return updateTabs((current) => {
+      const at = findTabIndex(current.tabs, target, index);
+      if (at < 0) {
+        // 待っている間に他の操作で消えていた。書き戻す必要がないので、
+        // storage.syncの書き込みクォータを無駄に使わずここで降りる
+        throw new Error('tab already removed');
+      }
+      return current.tabs.filter((_, i) => i != at);
+    });
+  };
+
+  // 指定したタブをまとめて取り除く。同じURL・名前のタブが複数あっても
+  // 指定した本数だけを消すため、まとめてfilterせず1件ずつ引く
+  const removeTabs = (targets: model.Tab[]): Promise<void> =>
+    updateTabs((current) => {
+      const remaining = [...current.tabs];
+      for (const target of targets) {
+        const at = remaining.findIndex((tab) => sameTab(tab, target));
+        if (at >= 0) {
+          remaining.splice(at, 1);
+        }
+      }
+      return remaining;
+    });
+
   // 結果を待たない導線用。失敗はApp側でerrorLogに記録済みなので、
   // ここで受けないとunhandled rejectionになるだけ
-  const updateTabsIgnoringFailure = (tabs: model.Tab[]): void => {
-    updateTabs(tabs).catch(() => {});
+  const removeTabAtIgnoringFailure = (index: number): void => {
+    removeTabAt(index).catch(() => {});
   };
 
   const openLink = (index: number) => {
-    const url = block.tabs[index]!.url;
+    const target = block.tabs[index]!;
     if (locked) {
       // ロック中は開くだけで一覧から消さない。書き戻しが要らないため
       // 飛行中としても数えない
       chromeService.tab
-        .createTabs({ url: url, active: false })
+        .createTabs({ url: target.url, active: false })
         .catch((error) => {
           chromeService.errorLog.set(error).catch(console.error);
         });
@@ -129,8 +200,10 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     // chrome.tabs.createを待つ間も飛行中として数える
     trackTabWrite(
       chromeService.tab
-        .createTabs({ url: url, active: false })
-        .then(() => deleteClick(index)),
+        .createTabs({ url: target.url, active: false })
+        // 開いたタブそのものを消す。書き込む直前の一覧で指し直すので、
+        // 待っている間に並びが変わっていても無関係なタブを巻き込まない
+        .then(() => removeTabAtIgnoringFailure(index)),
     ).catch((error) => {
       chromeService.errorLog.set(error).catch(console.error);
     });
@@ -142,7 +215,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     if (locked) {
       return;
     }
-    updateTabsIgnoringFailure(block.tabs.filter((_, i) => i != index));
+    removeTabAtIgnoringFailure(index);
   };
 
   // 保存できたときだけモーダルを閉じる。失敗時はrejectをモーダル側へ返し、
@@ -154,9 +227,15 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     if (editTargetIndex < 0) {
       return Promise.reject(new Error('edit target lost'));
     }
-    return updateTabs(
-      block.tabs.map((tab, i) => (i == editTargetIndex ? newTab : tab)),
-    ).then(() => {
+    return updateTabs((current) => {
+      // 書き込む直前の一覧で指し直す。propsのindexは待っている間に
+      // ずれうるので、そのまま使うと別のタブを上書きする
+      const at = findEditTargetIn(current.tabs);
+      if (at < 0) {
+        throw new Error('edit target lost');
+      }
+      return current.tabs.map((tab, i) => (i == at ? newTab : tab));
+    }).then(() => {
       closeTabEdit();
     });
   };
@@ -191,9 +270,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
       ).then(() => {
         // 開いたタブだけを消す。開けなかったタブまでブロックごと消すと、
         // 一覧に見えていたタブが開かれもせず失われる
-        updateTabsIgnoringFailure(
-          block.tabs.filter((tab) => !openableTab(tab)),
-        );
+        removeTabs(openTabs).catch(() => {});
       }),
     ).catch((error) => {
       chromeService.errorLog.set(error).catch(console.error);
@@ -204,7 +281,8 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     if (locked) {
       return;
     }
-    updateTabsIgnoringFailure([]);
+    // タブが空になったブロックはstorage側で削除される
+    updateTabs(() => []).catch(() => {});
   };
 
   /**
@@ -226,11 +304,14 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     setLockError(null);
     setLockSaving(true);
     trackTabWrite(
-      props.updateBlock({
-        ...block,
-        // ロックしていない状態はキーを持たない形で表す（保存側もそう書く）
+      props.updateBlock(block.indexNum, (current) => ({
+        ...current,
+        // ロックしていない状態はキーを持たない形で表す（保存側もそう書く）。
+        // 押したときに見えていた状態の裏返しにする。書き込む直前の内容から
+        // 裏返すと、待っている間に他のページで切り替わっていた場合に
+        // ユーザーが押したのと逆の結果になる
         locked: locked ? undefined : true,
-      }),
+      })),
     ).then(
       () => {
         setLockSaving(false);
@@ -265,11 +346,12 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     setStarError(null);
     setStarSaving(true);
     trackTabWrite(
-      props.updateBlock({
-        ...block,
-        // お気に入りでない状態はキーを持たない形で表す（保存側もそう書く）
+      props.updateBlock(block.indexNum, (current) => ({
+        ...current,
+        // お気に入りでない状態はキーを持たない形で表す（保存側もそう書く）。
+        // ロックと同じく、押したときに見えていた状態の裏返しにする
         starred: starred ? undefined : true,
-      }),
+      })),
     ).then(
       () => {
         setStarSaving(false);
@@ -332,13 +414,13 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     setTitleError(null);
     setTitleSaving(true);
     props
-      .updateBlock({
+      .updateBlock(block.indexNum, (current) => ({
         // 編集している間はタブ側の導線を止めてあるので、このページの操作では
-        // タブ配列は変わらない。一覧の読み直し(#249)で変わることはあるため、
-        // 編集を始めた時点ではなく最新のpropsを書き戻す
-        ...block,
+        // タブ配列は変わらない。一覧の読み直し(#249)や他端末の変更で
+        // 変わることはあるため、書き込む直前の内容に名前だけを載せる
+        ...current,
         title: newTitle.length <= 0 ? undefined : newTitle,
-      })
+      }))
       .then(() => {
         setTitleDraft(null);
         setTitleSaving(false);
@@ -446,20 +528,13 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // 最初からindexを捨てて内容で探すと、同じURL・同じ名前のタブを複数持つ
   // ブロック（同じページを2枚開いて保存した場合など）で、常に先頭の重複を
   // 書き換えてしまう
-  const sameAsEditTarget = (tab: model.Tab): boolean =>
-    editTarget != null &&
-    tab.url === editTarget.url &&
-    tab.title === editTarget.title;
-  const editTargetIndex = ((): number => {
+  const findEditTargetIn = (tabs: model.Tab[]): number => {
     if (editTarget == null || editIndex == null) {
       return -1;
     }
-    const atEditIndex = block.tabs[editIndex];
-    if (atEditIndex != null && sameAsEditTarget(atEditIndex)) {
-      return editIndex;
-    }
-    return block.tabs.findIndex(sameAsEditTarget);
-  })();
+    return findTabIndex(tabs, editTarget, editIndex);
+  };
+  const editTargetIndex = findEditTargetIn(block.tabs);
   // 編集していたタブが失われたか。この場合もモーダルは閉じず、入力を見せた
   // まま保存だけを止める（黙って消すと、書いていた内容が理由も分からず
   // 失われる）。ブロックごと消えた場合はカードがアンマウントされるため、

--- a/src/js/components/main.tsx
+++ b/src/js/components/main.tsx
@@ -10,7 +10,10 @@ interface MainProps {
   blocks: model.BlockEntry[];
   // 直前の更新が他のtabsページ・他端末の変更（storageの読み直し）由来か
   fromStorage: boolean;
-  updateBlock: (newBlock: model.Block) => Promise<void>;
+  updateBlock: (
+    indexNum: number,
+    update: (current: model.Block) => model.Block,
+  ) => Promise<void>;
   deleteBrokenBlock: (indexNum: number) => void;
 }
 


### PR DESCRIPTION
> [!NOTE]
> 下に積んでいた #260（さらにその下の #259）がマージされたため、base を `master` に切り替えて開き直しました。この上には #262 が積まれています。

## 概要

同じブロックに対する `updateBlock` が並行すると、後から着地した書き込みが相手の変更を打ち消す。`updateBlock` はブロックを丸ごと書き戻す一方、各操作はクリック時の props をクロージャに閉じ込めたまま `chrome.tabs.create` と storage への書き込みを待つため、**削除したはずのブロック／タブが復活する**。

## 変更内容

### `updateBlock` を updater 形式に

```ts
// 変更前: (newBlock: model.Block) => Promise<void>
// 変更後:
updateBlock: (
  indexNum: number,
  update: (current: model.Block) => model.Block,
) => Promise<void>
```

`app.tsx` は **`indexNum` ごとに書き込みを直列化**し、書き込む直前の一覧から現在のブロックを渡す。

- **待っている間に消えた／壊れたと分かったブロックには書き戻さない**。これがケース1（削除したブロックの復活）の根治
- 直前の書き込みが失敗しても次を走らせる。失敗でキューを止めると、以降そのブロックを操作できなくなる
- **飛行中の書き込みがなければキューを挟まずその場で始める**。待たせるだけのマイクロタスクを入れると、書き込み中の表示（`tabsWriting`）が独立したレンダリングとして一瞬見えてしまう（実際、既存の「あるブロックの更新時に他のブロックは再レンダリングされない」テストがこれを検知した）
- 一覧の写し（`blocksRef`）は**レンダリング時ではなく state を進めるのと同じタイミング**で進める。次に積まれた書き込みは再レンダリングを待たずに走るため、ref が遅れると直前の書き込みが反映される前の内容の上に書いてしまう

### タブを index ではなく同一性で指し直す

`block.tsx` は、書き込む直前の一覧でタブを指し直す。待っている間に並びが変わると、index のままでは開いてもいないタブを消してしまう。

- 同じ URL・名前のタブが並ぶブロックで押した行を取り違えないよう、**まず index の位置が同じ内容のままかを確かめ、ずれていたら内容で探す**。これは編集モーダルが #242 で入れていた判定と同じもので、`findTabIndex` として共通化した
- 保存データが壊れてタブ自体が `null` のときは内容で見分けられないため、同じ「壊れたタブ」として扱う
- 待っている間に他の操作で消えていたタブは書き戻さずに降りる（`storage.sync` の書き込みクォータを無駄に使わない）

### 削除の導線も同じキューに乗せる

直列化を `enqueueWrite` に切り出し、**壊れたブロックの削除**も同じキューに乗せた。

**全データ削除**は、飛行中の書き込みを待つだけでは足りない。`allClear` が着地するまで `blocksRef` は削除前の一覧のままなので、その窓でカード内を操作すると「消えたブロックには書き戻さない」ガードをすり抜けて `setBlock` が走り、消したはずのブロックが storage に戻る（画面は0件のままなので気付けない）。`clearingAll` の ref を立て、その間に始まる書き込みは書かずに解決する。

### ロックの判定を書き込む直前にも

押した時点で解除されていても、待っている間にロックされたブロックへ書き戻すと、ロックが守るはずだったタブを消してしまう。呼び出し時の props と書き込み直前の内容の両方で見る。

## テスト

`app.test.tsx` に `describe('App ブロックへの書き込みが重なったとき')` を追加。いずれも **修正前の実装を忠実に再現すると落ちる**ことを確認済み。

1. **ケース1**: リンクを開いている最中（`chrome.tabs.create` 保留）にブロックを削除 → 開き終わっても書き戻さない
2. **ケース2**: 1件目の書き込みが飛行中のまま2件目のタブを削除 → 2件目が1件目の結果の上に積まれ、両方の削除が残る（クリック時の props から書き戻すと `title-a` が復活する）
3. **並び替え**: 2件目のリンクを開いている間に1件目を削除 → 開いたタブだけが消える

さらに、キューと「書き込む直前の内容に載せる」ことを回帰検知できるようにした。

- `describe('App ブロックへの書き込みが重なったとき')`: 3件積む / 先の書き込みが着地したあとに積む / 失敗しても次が走る / 全データ削除が飛行中の書き込みを待つ / 全データ削除の最中に始まった書き込みは書き戻さない / 壊れたブロックの削除もキューに乗る / 開いたタブが先に消えていたら書き戻さない
- `describe('Block 書き込む直前に内容が変わっていたとき')`: `savedBlock(updateBlock, {current})` で props とずれた内容を渡し、タブ削除・名前保存・ロック・お気に入りが**書き込む直前の内容**を引き継ぐこと、ロック／編集対象消失で書き換えないことを固定

**以下の変異がすべてテストで落ちることを確認済み**（当初は1件も落ちなかった）:

`submitTitle` / `toggleLock` / `toggleStar` の `...current` → `...block`、`updateTabs` の書き込み直前 `locked` 判定の削除、`saveEditedTab` の `current` 解決をクリック時の index に戻す、`removeTabAt` の `findTabIndex` → `index`、キュー cleanup の最後尾判定の削除、直前の書き込みの失敗吸収の削除、全データ削除の待ち合わせの削除、`clearingAll` ガードの削除、`removeTabs` の空振り防止の削除、`deleteBrokenBlock` のキュー外し。

既存の `block.test.tsx` は `savedBlock()` ヘルパで追随させた（アサーションの意味は変えていない）。

`npm run format:check` / `npm run lint` / `npm test`（14 suites, 336 tests）すべて通過。CI も pass。

## 未対応として残したもの

- **`reload()` が `blocksRef` を巻き戻す**: 書き込み前に発行された `getAllBlock` が書き込み後に着地すると、写しが古い内容に戻る。この PR 以前も state が同じように巻き戻っており、画面に見えている内容と書く内容は一致するため回帰ではない。直すなら `reload()` に世代番号が要る
- **`openAllTab` は1件でも開けなかったら1本も消さない**（`Promise.all`）: 既存挙動。開けた分だけ消すと、失敗したタブだけが残ったのか全部残ったのかをユーザーが見分けられないため、コメントで明文化するに留めた
- **全データ削除の待ち合わせに上限がない**: 飛行中の `chrome.storage.sync.set` が返らない状況（拡張の更新でページの context が無効になる等）では `deleteAllBlocks` が pending のままになり、alert もエラーも出ない。`Promise.allSettled` なので reject しないことは意図どおり

## 手動確認（未実施 / レビュー時にお願いしたい点）

タブ2件のブロックで1件目のリンクをクリックした直後に「すべてのリンクを閉じる」→ **ページをリロードしてもブロックが復活しないこと**。

Closes #248
Refs #229

