### PR TITLE
ロックとお気に入りのトグルをフックへ揃える

### DIFF
--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -1080,7 +1080,10 @@ describe('Block 編集のロック', (): void => {
 
     await clickLockToggle();
 
-    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: false });
+    // 引数の形ではなく「抑えていないこと」を見る。
+    // 等価なfocus()に戻す実装でも通ってほしい
+    expect(focusSpy).toHaveBeenCalled();
+    expect(focusSpy.mock.calls[0]?.[0]?.preventScroll).not.toBe(true);
   });
 });
 
@@ -1372,7 +1375,7 @@ describe('Block お気に入り', (): void => {
 
     await clickStarToggle();
 
-    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    expect(focusSpy.mock.calls[0]?.[0]?.preventScroll).toBe(true);
   });
 
   /**

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -1064,6 +1064,24 @@ describe('Block 編集のロック', (): void => {
         .hasAttribute('disabled'),
     ).toBe(true);
   });
+  // お気に入りと違いカードが動かないため、スクロールを抑えない。
+  // 画面外のボタンへフォーカスが戻ったときは、見えるところまで運んでほしい。
+  // 共通のフックへ寄せたあとも、お気に入りとの違いが残ることを固定する(#254)
+  test('キーボードのフォーカス復帰でスクロールを抑えない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(
+      [{ url: 'https://example.com/a', title: 'title-a' }],
+      updateBlock,
+    );
+    const focusSpy = jest.spyOn(
+      container.querySelector<HTMLButtonElement>('.block-lock-toggle')!,
+      'focus',
+    );
+
+    await clickLockToggle();
+
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: false });
+  });
 });
 
 describe('Block お気に入り', (): void => {
@@ -1340,7 +1358,10 @@ describe('Block お気に入り', (): void => {
   });
 
   // フォーカスに伴うブラウザの瞬間スクロールは、useBlockMoveAnimationが
-  // カードの移動に合わせて見せているスクロールを乱す
+  // カードの移動に合わせて見せているスクロールを乱す。
+  // ロック側は逆に抑えない（カードが動かないので抑える理由がなく、
+  // 画面外のボタンへ戻ったときは見えるところまで運んでほしい）ので、
+  // 共通のフックへ寄せたあとも違いが残っていることを固定する(#254)
   test('キーボードのフォーカス復帰でスクロールを起こさない', async (): Promise<void> => {
     const updateBlock = jest.fn().mockResolvedValue(undefined);
     await mount(updateBlock);

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -5,6 +5,7 @@ import { openableTab, Tab } from './tab';
 import BrokenTab from './brokenTab';
 import EditTabModal from './editTabModal';
 import { ErrorBoundary } from './errorBoundary';
+import { useBlockFlagToggle } from './useBlockFlagToggle';
 
 // 名前の入力欄に入れられる長さの上限。カードの見出しに収まる長さに抑えることと、
 // storage.syncの8KB/item制限を名前で圧迫しないことが目的。
@@ -70,23 +71,6 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   const [titleError, setTitleError] = useState<string | null>(null);
   const titleFieldId = useId();
   const titleHintId = useId();
-  const [lockError, setLockError] = useState<string | null>(null);
-  // ロックの書き込みが飛行中かどうか。着地するまでpropsのlockedは古いままなので、
-  // その間に始まったタブ操作は自分がロック中であることを知らずに書き戻す
-  const [lockSaving, setLockSaving] = useState(false);
-  const [starError, setStarError] = useState<string | null>(null);
-  // スターの書き込みが飛行中かどうか。ロックと同じ理由で、着地するまでは
-  // タブ側の導線を止める
-  const [starSaving, setStarSaving] = useState(false);
-
-  // 誤操作からブロックを守るための状態。ロック中は削除・編集の導線を止め、
-  // リンクを開いてもタブを一覧から消さない
-  const locked = block.locked === true;
-
-  // お気に入りかどうか。一覧での並び順と装飾にしか影響しないため、
-  // ロック中でも付け外しできる（ロックはデータを失う操作を止めるためのもの）
-  const starred = block.starred === true;
-
   // 飛行中のタブ書き換えの本数。propsを見ても決着していない書き込みは
   // 分からないため、名前の編集を始めさせないための判断材料として自前で数える
   const tabWritesInFlight = useRef(0);
@@ -121,6 +105,52 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
       },
     );
   };
+
+  /*
+   * カード全体に効く真偽値フラグの切り替え。
+   * ロックとお気に入りは同じ振る舞いなので同じフックへ寄せる(#254)。
+   *
+   * canStartに関数を渡すのは、開始条件（blockWriteBusy）が
+   * 両方のsavingを含むため。フックを呼ぶ時点ではまだ算出できないので、
+   * クリックの時点で評価する。
+   *
+   * ロックの切り替えは、着地するまでpropsのlockedが古いままで、その隙に
+   * 始まったタブ操作がロックを知らないまま書き戻してしまうため、
+   * 名前の保存と同じようにタブ側の導線も止める（tabsLocked）。
+   *
+   * お気に入りはロック中でも押せる。並び順と装飾にしか効かず、タブを失う
+   * 操作ではないため。なおロック中のブロックをstorageへ書き戻せる＝保存は
+   * 常に現在のスキーマ版数で行われる（v1/v2で保存されていたブロックはv3に
+   * なる）。ロックはこの拡張機能のUIでの誤操作を防ぐもので、保存データを
+   * 変えさせない仕組みではない、という既存の立場のままとする
+   */
+  const lock = useBlockFlagToggle({
+    block: block,
+    field: 'locked',
+    updateBlock: props.updateBlock,
+    track: trackTabWrite,
+    canStart: () => !blockWriteBusy,
+    failureMessageKey: 'content_msg_lock_block_save_failed',
+  });
+  const star = useBlockFlagToggle({
+    block: block,
+    field: 'starred',
+    updateBlock: props.updateBlock,
+    track: trackTabWrite,
+    canStart: () => !blockWriteBusy,
+    failureMessageKey: 'content_msg_star_block_save_failed',
+    // お気に入りはカードが一覧内を移動する。フォーカスに伴うブラウザの
+    // 瞬間スクロールが、useBlockMoveAnimationがカードの移動に合わせて
+    // 見せているスクロールを乱すため抑える
+    preventScroll: true,
+  });
+
+  // 誤操作からブロックを守るための状態。ロック中は削除・編集の導線を止め、
+  // リンクを開いてもタブを一覧から消さない
+  const locked = lock.active;
+
+  // お気に入りかどうか。一覧での並び順と装飾にしか影響しない
+  const starred = star.active;
 
   // タブ配列の差し替えをApp経由でstorageへ反映する。
   // updateBlockはブロックごと書き戻すため、タブだけを変える導線でも
@@ -293,87 +323,6 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     updateTabs(() => []).catch(() => {});
   };
 
-  /**
-   * ロックを切り替えてstorageへ反映する。
-   * ロックもブロックごと書き戻すため、名前・タブの書き込みと並行すると
-   * 後から着地した側が相手の変更を打ち消す。名前の保存が名前の編集中として
-   * タブ側を止めているのと同じように、着地するまではタブ側の導線も止める
-   * （propsのlockedは着地するまで古いままなので、その隙に始まったタブ操作は
-   * ロックを知らないまま書き戻し、ロックごとブロックを消してしまう）
-   */
-  const toggleLock = (event: React.MouseEvent) => {
-    if (blockWriteBusy) {
-      return;
-    }
-    // キーボードから起動したクリックはdetailが0になる。
-    // ブラウザはmousedownでもボタンにフォーカスを移すため、
-    // activeElementを見てもマウス操作と区別できない
-    lockKeyboardActivated.current = event.detail === 0;
-    setLockError(null);
-    setLockSaving(true);
-    trackTabWrite(
-      props.updateBlock(block.indexNum, (current) => ({
-        ...current,
-        // ロックしていない状態はキーを持たない形で表す（保存側もそう書く）。
-        // 押したときに見えていた状態の裏返しにする。書き込む直前の内容から
-        // 裏返すと、待っている間に他のページで切り替わっていた場合に
-        // ユーザーが押したのと逆の結果になる
-        locked: locked ? undefined : true,
-      })),
-    ).then(
-      () => {
-        setLockSaving(false);
-      },
-      () => {
-        setLockSaving(false);
-        // App側のアラートはページ最上部に出るためスクロール中は気付けない。
-        // 押しても状態が変わらない理由をカード内でも伝える
-        setLockError(
-          chrome.i18n.getMessage('content_msg_lock_block_save_failed'),
-        );
-      },
-    );
-  };
-
-  /**
-   * スターを切り替えてstorageへ反映する。
-   * ロックと同じくブロックごと書き戻すため、名前・タブ・ロックの書き込みと
-   * 並行させない。ロック中でも押せる点だけがロックの切り替えと異なる
-   * （お気に入りは並び順と装飾にしか効かず、タブを失う操作ではない）。
-   * なおロック中でも押せる＝ロック中のブロックをstorageへ書き戻せるため、
-   * 保存は常に現在のスキーマ版数で行われる（v1/v2で保存されていたブロックは
-   * v3になる）。ロックはこの拡張機能のUIでの誤操作を防ぐもので、
-   * 保存データを変えさせない仕組みではない、という既存の立場のままとする
-   */
-  const toggleStar = (event: React.MouseEvent) => {
-    if (blockWriteBusy) {
-      return;
-    }
-    // キーボードから起動したクリックはdetailが0になる（ロックと同じ判定）
-    starKeyboardActivated.current = event.detail === 0;
-    setStarError(null);
-    setStarSaving(true);
-    trackTabWrite(
-      props.updateBlock(block.indexNum, (current) => ({
-        ...current,
-        // お気に入りでない状態はキーを持たない形で表す（保存側もそう書く）。
-        // ロックと同じく、押したときに見えていた状態の裏返しにする
-        starred: starred ? undefined : true,
-      })),
-    ).then(
-      () => {
-        setStarSaving(false);
-      },
-      () => {
-        setStarSaving(false);
-        // App側のアラートはページ最上部に出るためスクロール中は気付けない
-        setStarError(
-          chrome.i18n.getMessage('content_msg_star_block_save_failed'),
-        );
-      },
-    );
-  };
-
   // Tab側でもロック中は編集アイコンを無効化しているが、モーダルを開く判断は
   // ブロックの状態を持つこちらでも確かめる
   const startTabEdit = (index: number) => {
@@ -456,12 +405,6 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // キーボード操作の現在位置が失われる。開いたときのボタンへ戻す
   const cardRoot = useRef<HTMLDivElement>(null);
   const titleEditButton = useRef<HTMLButtonElement>(null);
-  const lockButton = useRef<HTMLButtonElement>(null);
-  const starButton = useRef<HTMLButtonElement>(null);
-  // ロックの切り替えをキーボードから起動したか
-  const lockKeyboardActivated = useRef(false);
-  // スターの切り替えをキーボードから起動したか
-  const starKeyboardActivated = useRef(false);
   const titleWasEditing = useRef(false);
   useEffect(() => {
     if (titleWasEditing.current && titleDraft == null) {
@@ -479,57 +422,6 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     }
     titleWasEditing.current = titleDraft != null;
   }, [titleDraft]);
-
-  // ロックボタンは押した瞬間に自分がdisabledになるため、ブラウザがフォーカスを
-  // bodyへ落とす。書き込みが決着したらキーボード操作の現在位置を戻す。
-  // 名前の編集と違い、押した後もボタン自体は同じ場所に残るので、
-  // フォーカスが失われている場合だけ戻せば足りる
-  const lockWasSaving = useRef(false);
-  useEffect(() => {
-    if (lockWasSaving.current && !lockSaving) {
-      // キーボードから押したときだけ戻す。マウスで押してから別の場所を
-      // クリックした場合もフォーカスはbodyに落ちるため、bodyかどうかだけで
-      // 判断すると、見ている位置から勝手にスクロールが戻ってしまう
-      const active = document.activeElement;
-      if (
-        lockKeyboardActivated.current &&
-        (active == null || active === document.body)
-      ) {
-        lockButton.current?.focus();
-      }
-    }
-    lockWasSaving.current = lockSaving;
-  }, [lockSaving]);
-
-  // スターボタンもロックボタンと同じ理由でフォーカスを戻す。
-  // スターは並び順も変えるためカード自体が一覧内を移動するが、
-  // ボタンはアンマウントされないのでrefから同じ要素へ戻せる。
-  // preventScrollを付けるのは、フォーカスに伴うブラウザの瞬間スクロールが、
-  // useBlockMoveAnimationがカードの移動に合わせて見せているスクロールを
-  // 乱すため
-  const starWasSaving = useRef(false);
-  useEffect(() => {
-    if (starWasSaving.current && !starSaving) {
-      const active = document.activeElement;
-      if (
-        starKeyboardActivated.current &&
-        (active == null || active === document.body)
-      ) {
-        starButton.current?.focus({ preventScroll: true });
-      }
-    }
-    starWasSaving.current = starSaving;
-  }, [starSaving]);
-
-  // 別の操作が成功してブロックが書き換わったら、前のロック失敗の赤字は
-  // 現在の状態を説明していない。直近の操作が失敗したかのように見えるため消す。
-  // 一覧の読み直し(#249)でも新しいオブジェクトが降りてくるため、他端末の
-  // 変更で赤字が消えることはある。失敗自体はerrorLog経由でページ上部の
-  // アラートに残るので、消える方に倒している
-  useEffect(() => {
-    setLockError(null);
-    setStarError(null);
-  }, [block]);
 
   // 編集対象のいまの位置。開いている間に一覧が読み直されるとindexの指す先が
   // ずれるため、ずれていたときだけ同じ内容のタブを探し直す。
@@ -564,7 +456,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // ロックの書き込み中も同じ理由でタブ側を止める。着地するまでpropsのlockedは
   // 古いままで、その間に始まったタブ操作はロックを知らないまま書き戻す。
   // スターの書き込み中も同じ（着地前のタブ操作はスターごと書き戻してしまう）
-  const tabsLocked = editing || titleEditing || lockSaving || starSaving;
+  const tabsLocked = editing || titleEditing || lock.saving || star.saving;
   // カード全体に効く操作（ロック・お気に入り）を始めてよいか。
   // どれもブロックごと書き戻すため、他の書き込みと並行すると打ち消し合う。
   // ボタンのdisabledでも塞いでいるが、保護をDOMの属性だけに預けない
@@ -597,7 +489,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
             状態はロックと同じ理由でaria-pressedではなく名前で伝える */}
         <button
           type="button"
-          ref={starButton}
+          ref={star.buttonRef}
           className="uk-link block-star-toggle"
           data-starred={starred}
           data-uk-icon="icon: star; ratio: 0.9"
@@ -609,7 +501,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
           )}
           // ロックボタンと同じ理由。ブロックごとの書き戻しが打ち消し合う
           disabled={tabsWriting || titleEditing}
-          onClick={toggleStar}
+          onClick={star.toggle}
         />
         {/* ロックの切り替えはカードの右上に置く。名前の編集や個々のタブの
             操作より上位の、カード全体に効く操作であるため。
@@ -621,7 +513,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
             見えているツールチップと名前が食い違って音声操作の的も外れる */}
         <button
           type="button"
-          ref={lockButton}
+          ref={lock.buttonRef}
           className="uk-link block-lock-toggle"
           data-locked={locked}
           data-uk-icon={`icon: ${locked ? 'lock' : 'unlock'}; ratio: 0.9`}
@@ -634,7 +526,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
           // 名前の編集中とタブの書き換え中は、ブロックごとの書き戻しが
           // 打ち消し合うため切り替えさせない
           disabled={tabsWriting || titleEditing}
-          onClick={toggleLock}
+          onClick={lock.toggle}
         />
         {titleEditing ? (
           <form
@@ -754,19 +646,19 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
         {/* エラーはロックボタンと同じヘッダ内の、見出しの後に出す。
             見出しより前に差し込むとカードの中身が丸ごとずれて、
             どのブロックの話か分かりにくくなる */}
-        {lockError != null ? (
+        {lock.error != null ? (
           <p className="uk-text-danger block-lock-error" role="alert">
-            {lockError}
+            {lock.error}
           </p>
         ) : null}
-        {starError != null ? (
+        {star.error != null ? (
           <p className="uk-text-danger block-star-error" role="alert">
-            {starError}
+            {star.error}
           </p>
         ) : null}
         <div
           className="uk-grid"
-          inert={titleEditing || lockSaving || starSaving}
+          inert={titleEditing || lock.saving || star.saving}
         >
           <div className="uk-width-auto">
             <span className="all_tab_link uk-link" onClick={openAllTab}>

--- a/src/js/components/useBlockFlagToggle.ts
+++ b/src/js/components/useBlockFlagToggle.ts
@@ -28,9 +28,24 @@ import { model } from '../types/interface';
  *    違いを違いのまま残す
  */
 
-// 切り替えの対象にできるフィールド。値を持たない状態をキーなしで表すため、
-// 型もundefinedを許す形にそろえる
-export type BlockFlagField = 'locked' | 'starred';
+/*
+ * 切り替えの対象にできるフィールド。
+ * 立っていない状態をキーなしで表すため、undefinedを許す真偽値のキーだけを拾う。
+ * 計算プロパティ（[field]: ...）は書き込む値の型を検査せず、
+ * 'locked' | 'starred' と手で書くと将来キーを足すときに
+ * 真偽値でないフィールド（titleなど）を混ぜても通ってしまう。
+ * その状態で押すと{...current, title: true}がstorageまで届き、
+ * 名前がtrueとして保存される
+ */
+type BooleanFlagKeys<T> = {
+  [K in keyof T]-?: undefined extends T[K]
+    ? NonNullable<T[K]> extends boolean
+      ? K
+      : never
+    : never;
+}[keyof T];
+
+export type BlockFlagField = BooleanFlagKeys<model.Block>;
 
 export type BlockFlagToggleOptions = {
   // 対象のブロック。indexNumの取得と、書き換わったら失敗表示を消すのに使う
@@ -45,8 +60,11 @@ export type BlockFlagToggleOptions = {
   track: <T>(work: Promise<T>) => Promise<T>;
   // 切り替えを始めてよいか。クリックの時点で評価する
   canStart: () => boolean;
-  // 失敗したときにカード内へ出す文言のキー
-  failureMessageKey: string;
+  // 失敗したときにカード内へ出す文言のキー。
+  // getMessageは知らないキーに空文字を返し、中身のない赤字と
+  // 空のrole="alert"を出してしまうので、実在するキーだけに絞る
+  failureMessageKey:
+    'content_msg_lock_block_save_failed' | 'content_msg_star_block_save_failed';
   // フォーカスを戻すときにブラウザの瞬間スクロールを抑えるか
   preventScroll?: boolean;
 };

--- a/src/js/components/useBlockFlagToggle.ts
+++ b/src/js/components/useBlockFlagToggle.ts
@@ -1,0 +1,155 @@
+import { RefObject, useEffect, useRef, useState } from 'react';
+import { model } from '../types/interface';
+
+/*
+ * カード全体に効く真偽値フラグの切り替え (#254)
+ *
+ * ロック(#194)とお気に入り(#196)は「ブロックの真偽値フラグを1つ裏返して
+ * storageへ書き戻す」という同じ振る舞いで、状態・トグル・フォーカス復帰まで
+ * 同型の実装が2組並んでいた。ここへ寄せる。
+ *
+ * 設計上の判断が2つある。
+ *
+ * 1. 開始条件はフックの外で決める
+ *    切り替えを始めてよいかの判定は「他方の保存中でないこと」を含むため、
+ *    自分のsavingしか知らないフックには組み立てられない。呼び出し側が
+ *    両方のsavingを見て算出したものを、遅延評価の関数として受け取る
+ *    （フックを呼ぶ時点ではまだ算出されていないので、値では渡せない）。
+ *    判定そのものは呼び出し側に残るが、「押せないときは何もしない」という
+ *    不変条件はここで守る。ボタンのdisabledだけに預けると、導線が増えたときに
+ *    保護が黙って外れる
+ *
+ * 2. フォーカス復帰のpreventScrollはオプションにする
+ *    お気に入りはカードが一覧内を移動し、useBlockMoveAnimationが画面の
+ *    スクロールを見せるため、フォーカスに伴うブラウザの瞬間スクロールを
+ *    抑える必要がある。ロックはカードが動かないので抑える理由がなく、
+ *    むしろ画面外のボタンへフォーカスが戻ったときに見えるところまで
+ *    運んでくれる。揃えるとロック側の挙動(#194)を変えることになるため、
+ *    違いを違いのまま残す
+ */
+
+// 切り替えの対象にできるフィールド。値を持たない状態をキーなしで表すため、
+// 型もundefinedを許す形にそろえる
+export type BlockFlagField = 'locked' | 'starred';
+
+export type BlockFlagToggleOptions = {
+  // 対象のブロック。indexNumの取得と、書き換わったら失敗表示を消すのに使う
+  block: model.Block;
+  field: BlockFlagField;
+  // storageへの書き戻し。更新関数を渡す形はApp側と同じ(#248)
+  updateBlock: (
+    indexNum: number,
+    update: (current: model.Block) => model.Block,
+  ) => Promise<void>;
+  // 書き込みを飛行中として数える。名前の編集との相互排他に使う
+  track: <T>(work: Promise<T>) => Promise<T>;
+  // 切り替えを始めてよいか。クリックの時点で評価する
+  canStart: () => boolean;
+  // 失敗したときにカード内へ出す文言のキー
+  failureMessageKey: string;
+  // フォーカスを戻すときにブラウザの瞬間スクロールを抑えるか
+  preventScroll?: boolean;
+};
+
+export type BlockFlagToggle = {
+  // 押したときに見えている状態
+  active: boolean;
+  // 書き込みが飛行中か。着地するまでpropsは古いままなので、
+  // 呼び出し側はこれを見てタブ側の導線を止める
+  saving: boolean;
+  // 失敗をカード内で伝える文言。成功や別の更新で消える
+  error: string | null;
+  buttonRef: RefObject<HTMLButtonElement | null>;
+  toggle: (event: React.MouseEvent) => void;
+};
+
+/**
+ * ブロックの真偽値フラグを切り替えてstorageへ反映する。
+ * @param {BlockFlagToggleOptions} options 切り替えの対象と周辺の依存
+ * @return {BlockFlagToggle} 表示と操作に必要な状態・ハンドラ
+ */
+export function useBlockFlagToggle(
+  options: BlockFlagToggleOptions,
+): BlockFlagToggle {
+  const { block, field, updateBlock, track, canStart, failureMessageKey } =
+    options;
+  const active = block[field] === true;
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  // 切り替えをキーボードから起動したか
+  const keyboardActivated = useRef(false);
+
+  const toggle = (event: React.MouseEvent): void => {
+    if (!canStart()) {
+      return;
+    }
+    // キーボードから起動したクリックはdetailが0になる。
+    // ブラウザはmousedownでもボタンにフォーカスを移すため、
+    // activeElementを見てもマウス操作と区別できない
+    keyboardActivated.current = event.detail === 0;
+    setError(null);
+    setSaving(true);
+    track(
+      updateBlock(block.indexNum, (current) => ({
+        ...current,
+        // 立っていない状態はキーを持たない形で表す（保存側もそう書く）。
+        // 押したときに見えていた状態の裏返しにする。書き込む直前の内容から
+        // 裏返すと、待っている間に他のページで切り替わっていた場合に
+        // ユーザーが押したのと逆の結果になる
+        [field]: active ? undefined : true,
+      })),
+    ).then(
+      () => {
+        setSaving(false);
+      },
+      () => {
+        setSaving(false);
+        // App側のアラートはページ最上部に出るためスクロール中は気付けない。
+        // 押しても状態が変わらない理由をカード内でも伝える
+        setError(chrome.i18n.getMessage(failureMessageKey));
+      },
+    );
+  };
+
+  // ボタンは押した瞬間に自分がdisabledになるため、ブラウザがフォーカスを
+  // bodyへ落とす。書き込みが決着したらキーボード操作の現在位置を戻す。
+  // 名前の編集と違い、押した後もボタン自体は同じ場所に残るので、
+  // フォーカスが失われている場合だけ戻せば足りる。
+  // お気に入りはカードが一覧内を移動するが、ボタンはアンマウントされないので
+  // refから同じ要素へ戻せる
+  const wasSaving = useRef(false);
+  const preventScroll = options.preventScroll === true;
+  useEffect(() => {
+    if (wasSaving.current && !saving) {
+      // キーボードから押したときだけ戻す。マウスで押してから別の場所を
+      // クリックした場合もフォーカスはbodyに落ちるため、bodyかどうかだけで
+      // 判断すると、見ている位置から勝手にスクロールが戻ってしまう
+      const activeElement = document.activeElement;
+      if (
+        keyboardActivated.current &&
+        (activeElement == null || activeElement === document.body)
+      ) {
+        buttonRef.current?.focus({ preventScroll: preventScroll });
+      }
+    }
+    wasSaving.current = saving;
+  }, [saving, preventScroll]);
+
+  // 別の操作が成功してブロックが書き換わったら、前の失敗の赤字は現在の状態を
+  // 説明していない。直近の操作が失敗したかのように見えるため消す。
+  // 一覧の読み直し(#249)でも新しいオブジェクトが降りてくるため、他端末の
+  // 変更で赤字が消えることはある。失敗自体はerrorLog経由でページ上部の
+  // アラートに残るので、消える方に倒している
+  useEffect(() => {
+    setError(null);
+  }, [block]);
+
+  return {
+    active: active,
+    saving: saving,
+    error: error,
+    buttonRef: buttonRef,
+    toggle: toggle,
+  };
+}


### PR DESCRIPTION
> [!NOTE]
> #261 →#260 → #259 の上に積んでいます。base は `worktree-issue-248-serialize-block-writes`。#261 が `toggleLock` / `toggleStar` を updater 形式に変えているため、その上でないと衝突します。下の PR がマージされたら順に base を切り替えます。

## 概要

ロック（#194）とお気に入り（#196）は「ブロックの真偽値フラグを1つ裏返して storage へ書き戻す」という同じ振る舞いなのに、状態・トグル・フォーカス復帰まで同型の実装が2組並んでいた。`useBlockFlagToggle`（`src/js/components/useBlockFlagToggle.ts`）へ寄せる。

## 検討が必要だった2点の扱い

issue が挙げていた「素朴に切り出すと詰まる箇所」2つは、次のように判断した。

### 1. 開始条件は呼び出し側に残す

切り替えを始めてよいかの判定（`blockWriteBusy`）は「**他方の** 保存中でないこと」を含むため、自分の `saving` しか知らないフックには組み立てられない。呼び出し側が両方の `saving` を見て算出したものを、**遅延評価の関数**として受け取る形にした。

```ts
canStart: () => !blockWriteBusy,
```

値ではなく関数なのは、フックを呼ぶ時点ではまだ `blockWriteBusy` が算出されていないため（クリックの時点で評価する）。判定そのものは呼び出し側に残るが、「押せないときは何もしない」という不変条件はフックの中で守る。ボタンの `disabled` だけに預けると、導線が増えたときに保護が黙って外れる。

### 2. `preventScroll` はオプションにして、違いを違いのまま残す

お気に入りはカードが一覧内を移動し、`useBlockMoveAnimation` が画面のスクロールを見せるため、フォーカスに伴うブラウザの瞬間スクロールを抑える必要がある。ロックはカードが動かないので抑える理由がなく、**むしろ画面外のボタンへフォーカスが戻ったときに見えるところまで運んでほしい**。揃えるとロック側の挙動（#194）を変えることになるので、オプションで吸収した。

## 共通化が見合うかの見極め

issue が求めていた見極めについて。`block.tsx` は **-165 / +57 行**（108行減）で、消えたのは次の2組の重複。

| | 消えた重複 |
|---|---|
| 状態 | `lockError` / `lockSaving` と `starError` / `starSaving` |
| ref | `lockButton` / `starButton`、`lockKeyboardActivated` / `starKeyboardActivated`、`lockWasSaving` / `starWasSaving` |
| トグル | `toggleLock` / `toggleStar`（キーボード起動の判定・エラーリセット・書き戻し・成否の反映まで同型） |
| フォーカス復帰 | 2つの `useEffect`（`preventScroll` の有無以外は同一） |
| 失敗表示のクリア | `[block]` の `useEffect`（1つで両方を消していた） |

新設したフック側は約155行だが、その大半は「なぜそうするか」のコメントで、元も2箇所に同じ趣旨が書かれていた。**実コード量はほぼ変わらず、同じ判断を2箇所で保守する状態がなくなる**のが得られるもの。3つ目のフラグが増えたときに効く。抽象としては「カード全体に効く真偽値フラグ」1つに閉じており、漏れは `canStart` の1点に限定できたので、共通化して見合うと判断した。

## テスト

**振る舞いを変えていないので、既存テストは1件も直していない**（337件そのまま通過）。

そのうえで1件追加した。ロック側にはフォーカス復帰のテストがなく、上記の判断2（`preventScroll` の違い）が回帰検知されていなかったため。`preventScroll` を常に `true` にする変異でこのテストが落ちることを確認済み。`canStart` のガードを外す変異は既存テストが検知する。

`npm run format:check` / `npm run lint` / `npm test`（14 suites, 337 tests）すべて通過。

## 受け入れ条件

- [x] 振る舞いを変えない（既存テストがそのまま通る）
- [x] 重複していた状態・トグル・フォーカス復帰が1箇所になっている
- [x] 2点の判断がコードのコメントと本 PR に残っている

Closes #254
Refs #194
Refs #196
Refs #251
