### PR TITLE
Chromeのタブグループを保持したまま保存・復元する

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -24,6 +24,9 @@
   "content_msg_all_tab_open": {
     "message": "Open all links"
   },
+  "content_msg_tab_group_unnamed": {
+    "message": "Unnamed group"
+  },
   "content_msg_delete_block": {
     "message": "Delete block"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -24,6 +24,9 @@
   "content_msg_all_tab_open": {
     "message": "すべてのリンクを開く"
   },
+  "content_msg_tab_group_unnamed": {
+    "message": "名前のないグループ"
+  },
   "content_msg_delete_block": {
     "message": "ブロックを削除"
   },

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -341,3 +341,75 @@
 .uk-card-body[inert] {
   opacity: 0.5;
 }
+
+/*
+ * 保存時のタブグループ (#191)
+ *
+ * 「すべてのリンクを開く」で名前と色ごと戻ることが一覧で分かるように、
+ * タブ1行の先頭へ小さく出す。色だけで区別させると色覚特性によっては
+ * 読み取れないため、名前も併記して色は補助にとどめる。
+ * 色の値はChromeのタブグループが取りうる9色で、
+ * Chromeのグループ表示に寄せた彩度の低い色を使う。
+ */
+.tab-group-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: 6px;
+  padding: 0 6px;
+  border-radius: 8px;
+  background-color: #f0f0f0;
+  color: #333;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  /* 長いグループ名でタブのリンクが押し出されないようにする */
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tab-group-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  /* 知らない色が保存データに入っていても、点が消えて詰まって見えないようにする */
+  background-color: #5f6368;
+}
+
+.tab-group-chip[data-tab-group-color='grey'] .tab-group-dot {
+  background-color: #5f6368;
+}
+
+.tab-group-chip[data-tab-group-color='blue'] .tab-group-dot {
+  background-color: #1a73e8;
+}
+
+.tab-group-chip[data-tab-group-color='red'] .tab-group-dot {
+  background-color: #d93025;
+}
+
+.tab-group-chip[data-tab-group-color='yellow'] .tab-group-dot {
+  background-color: #f9ab00;
+}
+
+.tab-group-chip[data-tab-group-color='green'] .tab-group-dot {
+  background-color: #1e8e3e;
+}
+
+.tab-group-chip[data-tab-group-color='pink'] .tab-group-dot {
+  background-color: #d01884;
+}
+
+.tab-group-chip[data-tab-group-color='purple'] .tab-group-dot {
+  background-color: #9334e6;
+}
+
+.tab-group-chip[data-tab-group-color='cyan'] .tab-group-dot {
+  background-color: #007b83;
+}
+
+.tab-group-chip[data-tab-group-color='orange'] .tab-group-dot {
+  background-color: #fa903e;
+}

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -364,7 +364,16 @@
   line-height: 1.6;
   /* 長いグループ名でタブのリンクが押し出されないようにする */
   max-width: 12rem;
+}
+
+/*
+ * 省略記号はブロックコンテナにしか効かないため、inline-flexのチップ自体では
+ * なく中の要素に当てる。チップに書くと、はみ出した名前が
+ * 「…」なしでグリフの途中から切れて、途中までが本当の名前に見える
+ */
+.tab-group-name {
   overflow: hidden;
+  min-width: 0;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/src/js/background.test.ts
+++ b/src/js/background.test.ts
@@ -11,6 +11,8 @@ describe('background action.onClicked', (): void => {
   // ユーザーが別のウィンドウへ移っても、保存も終了もこのウィンドウを指す
   const CURRENT_WINDOW_ID = 1;
   let openedTabs: chrome.tabs.Tab[];
+  // 保存時のタブグループ(#191)。queryTabGroupsが投げる状況も作れるようにする
+  let tabGroups: chrome.tabGroups.TabGroup[] | Error;
   let clickAction: (tab: chrome.tabs.Tab) => void;
   const create = jest.fn();
   const update = jest.fn();
@@ -29,8 +31,15 @@ describe('background action.onClicked', (): void => {
     id: number,
     url: string,
     windowId: number = CURRENT_WINDOW_ID,
+    groupId = -1,
   ): chrome.tabs.Tab =>
-    ({ id: id, windowId: windowId, url: url, title: url }) as chrome.tabs.Tab;
+    ({
+      id: id,
+      windowId: windowId,
+      url: url,
+      title: url,
+      groupId: groupId,
+    }) as chrome.tabs.Tab;
 
   /**
    * chromeのAPIを差し替えたうえでbackgroundを読み込み、
@@ -73,6 +82,12 @@ describe('background action.onClicked', (): void => {
         remove: remove,
       },
       windows: { update: jest.fn() },
+      tabGroups: {
+        query: (): Promise<chrome.tabGroups.TabGroup[]> =>
+          tabGroups instanceof Error
+            ? Promise.reject(tabGroups)
+            : Promise.resolve(tabGroups),
+      },
     };
     const { chromeService } = await import('./chromeService');
     jest.spyOn(chromeService.storage, 'getNextBlockIndex').mockResolvedValue(3);
@@ -93,6 +108,7 @@ describe('background action.onClicked', (): void => {
 
   beforeEach((): void => {
     openedTabs = [];
+    tabGroups = [];
     create.mockClear();
     update.mockClear();
     move.mockClear();
@@ -112,6 +128,59 @@ describe('background action.onClicked', (): void => {
       await Promise.resolve();
     }
   };
+
+  // Chromeのタブグループを保持したまま保存する(#191)
+  test('タブグループの名前と色も保存する', async (): Promise<void> => {
+    openedTabs = [
+      tab(1, 'https://example.com/a', CURRENT_WINDOW_ID, 7),
+      tab(2, 'https://example.com/b'),
+    ];
+    tabGroups = [
+      { id: 7, title: '調査中', color: 'blue' } as chrome.tabGroups.TabGroup,
+    ];
+    await loadBackground();
+
+    await click();
+
+    expect(setBlock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        groups: [{ title: '調査中', color: 'blue' }],
+        tabs: [
+          expect.objectContaining({ url: 'https://example.com/a', group: 0 }),
+          // グループに属していないタブにキーを増やさない
+          { url: 'https://example.com/b', title: 'https://example.com/b' },
+        ],
+      }),
+    );
+  });
+
+  // グループが取れないことと、タブを保存できないことは別。
+  // ここで止めるとタブごと失う
+  test('タブグループの取得に失敗してもタブは保存する', async (): Promise<void> => {
+    openedTabs = [tab(1, 'https://example.com/a', CURRENT_WINDOW_ID, 7)];
+    tabGroups = new Error('no permission');
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    await loadBackground();
+
+    try {
+      await click();
+
+      expect(setBlock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tabs: [
+            { url: 'https://example.com/a', title: 'https://example.com/a' },
+          ],
+        }),
+      );
+      expect(setBlock.mock.calls[0][0].groups).toBeUndefined();
+      // 閉じる・tabsページを開くところまで従来どおり進む
+      expect(remove).toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
 
   test('現在のウィンドウの全タブを保存して閉じ、tabsページを開く', async (): Promise<void> => {
     openedTabs = [

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -34,7 +34,15 @@ async function saveWindowTabs(windowId: number): Promise<void> {
   // 空のブロックを書くとindexだけ進んで無駄な欠番が増えるため、
   // tabsページへの切り替えだけを行う
   if (currentTabs.length > 0) {
-    const block = blockService.createBlock(currentTabs, new Date(), nextIndex);
+    // タブグループの名前と色を保存に含める(#191)。取得に失敗しても
+    // グループなしとして保存を続ける（ここで止めるとタブごと失う）
+    const tabGroups = await chromeService.tab.queryTabGroups(windowId);
+    const block = blockService.createBlock(
+      currentTabs,
+      new Date(),
+      nextIndex,
+      tabGroups,
+    );
     await chromeService.storage.setBlock(block);
     await chromeService.storage.setTabLength(nextIndex + 1);
   }

--- a/src/js/blockService.test.ts
+++ b/src/js/blockService.test.ts
@@ -1276,6 +1276,95 @@ describe('blockService タブグループ', (): void => {
     expect(block.tabs[0]!.group).toBe(1);
   });
 
+  // groupsが配列でない・要素が壊れている場合。インポートしたJSONには
+  // 型の検証がないので何でも入りうる
+  test.each([
+    ['文字列', '"oops"'],
+    ['オブジェクト', '{"a":1}'],
+    ['数値', '3'],
+    ['空配列', '[]'],
+  ])(
+    'jsonToBlock groupsが配列でない(%s)ときはグループなしとして読む',
+    (_name: string, groupsJson: string): void => {
+      const json = `{"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"a","group":0}],"groups":${groupsJson}}`;
+
+      const block = blockService.jsonToBlock(json, 0);
+      expect(block.groups).toBeUndefined();
+      // 参照先がないので添字も落ちる
+      expect(block.tabs).toStrictEqual([
+        { url: 'https://example.com/a', title: 'a' },
+      ]);
+    },
+  );
+
+  // 同じ復元可能な情報をフィールドによって残したり捨てたりしない
+  // （ブロック名は数値を文字列として残す）
+  test('jsonToBlock 数値のグループ名は文字列として残す', (): void => {
+    const json =
+      '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"a","group":0}],"groups":[{"title":2026,"color":"blue"}]}';
+
+    expect(blockService.jsonToBlock(json, 0).groups).toStrictEqual([
+      { title: '2026', color: 'blue' },
+    ]);
+  });
+
+  // jsonObjToBlockとjsonToBlockが同じヘルパを共有していることの担保。
+  // 片方だけ検証していると、共有が崩れたときに気づけない
+  test('inflateJson(v2の非圧縮)でも同じように正規化する', async (): Promise<void> => {
+    const stored = JSON.stringify({
+      v: 2,
+      created_at: 1609556645678,
+      tabs: [
+        { url: 'https://example.com/a', title: 'a', group: 9 },
+        { url: 'https://example.com/b', title: 'b', group: 0 },
+      ],
+      groups: [{ title: '  調査中  ', color: 'chartreuse' }],
+    });
+
+    const block = await blockService.inflateJson(stored, 0);
+    expect(block.groups).toStrictEqual([{ title: '調査中', color: 'grey' }]);
+    expect(block.tabs).toStrictEqual([
+      // 範囲外の添字は落ちる
+      { url: 'https://example.com/a', title: 'a' },
+      { url: 'https://example.com/b', title: 'b', group: 0 },
+    ]);
+  });
+
+  // 読み込みで元のオブジェクトを書き換えると、呼び出し側が持っている
+  // 参照の中身が変わる
+  test('jsonToBlock 入力のタブを書き換えない', (): void => {
+    const tabs = [{ url: 'https://example.com/a', title: 'a', group: 9 }];
+    const json = JSON.stringify({ created_at: 1609556645678, tabs: tabs });
+
+    blockService.jsonToBlock(json, 0);
+
+    expect(tabs[0]!.group).toBe(9);
+  });
+
+  // v1のzlib経路もjsonToBlockを通る。かつてタブを{url,title}に
+  // 組み立て直しており、nullのタブでTypeErrorになってブロックごと落ちていた
+  test('jsonToBlock 壊れたタブはそのまま通す', (): void => {
+    const json =
+      '{"created_at":1609556645678,"tabs":[null,{"url":"https://example.com/a","title":"a"}]}';
+
+    expect(blockService.jsonToBlock(json, 0).tabs).toStrictEqual([
+      null,
+      { url: 'https://example.com/a', title: 'a' },
+    ]);
+  });
+
+  // 同じidのグループが複数あっても、最初の1件だけを採る
+  test('createBlock 同じidのグループが重複していても1件にまとめる', (): void => {
+    const block = blockService.createBlock(
+      [chromeTab('https://example.com/a', 'a', 7)],
+      createdAt,
+      0,
+      [chromeGroup(7, '先勝ち', 'blue'), chromeGroup(7, '後', 'red')],
+    );
+
+    expect(block.groups).toStrictEqual([{ title: '先勝ち', color: 'blue' }]);
+  });
+
   test('jsonToBlock groupsを持たない従来のデータはそのまま読める', (): void => {
     const json =
       '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"a"}]}';

--- a/src/js/blockService.test.ts
+++ b/src/js/blockService.test.ts
@@ -1119,3 +1119,190 @@ describe('blockService import/export', (): void => {
     },
   );
 });
+
+// Chromeのタブグループを保持したまま保存・復元する(#191)。
+// グループはブロック単位に持ち、タブからは添字で参照する
+describe('blockService タブグループ', (): void => {
+  const chromeTab = (
+    url: string,
+    title: string,
+    groupId: number,
+  ): chrome.tabs.Tab =>
+    ({ url: url, title: title, groupId: groupId }) as chrome.tabs.Tab;
+
+  const chromeGroup = (
+    id: number,
+    title: string | undefined,
+    color: string,
+  ): chrome.tabGroups.TabGroup =>
+    ({ id: id, title: title, color: color }) as chrome.tabGroups.TabGroup;
+
+  const createdAt = new Date('2021-01-02T03:04:05.678Z');
+
+  test('createBlock グループの名前と色をブロックに持ち、タブは添字で指す', (): void => {
+    const block = blockService.createBlock(
+      [
+        chromeTab('https://example.com/a', 'a', 7),
+        chromeTab('https://example.com/b', 'b', -1),
+        chromeTab('https://example.com/c', 'c', 7),
+      ],
+      createdAt,
+      0,
+      [chromeGroup(7, '調査中', 'blue')],
+    );
+
+    expect(block.groups).toStrictEqual([{ title: '調査中', color: 'blue' }]);
+    expect(block.tabs).toStrictEqual([
+      { url: 'https://example.com/a', title: 'a', group: 0 },
+      // グループに属していないタブにキーを増やさない
+      { url: 'https://example.com/b', title: 'b' },
+      { url: 'https://example.com/c', title: 'c', group: 0 },
+    ]);
+  });
+
+  // Chromeでは名前を付けずに色だけのグループを作れる
+  test('createBlock 名前のないグループは色だけを持つ', (): void => {
+    const block = blockService.createBlock(
+      [chromeTab('https://example.com/a', 'a', 7)],
+      createdAt,
+      0,
+      [chromeGroup(7, '', 'red')],
+    );
+
+    expect(block.groups).toStrictEqual([{ color: 'red' }]);
+  });
+
+  // 空のグループまで持つと、復元しても中身のないグループができる
+  test('createBlock タブが属していないグループは持たない', (): void => {
+    const block = blockService.createBlock(
+      [chromeTab('https://example.com/a', 'a', -1)],
+      createdAt,
+      0,
+      [chromeGroup(7, '使っていない', 'blue')],
+    );
+
+    expect(block.groups).toBeUndefined();
+    expect(block.tabs).toStrictEqual([
+      { url: 'https://example.com/a', title: 'a' },
+    ]);
+  });
+
+  test('createBlock グループを渡さなくても従来どおり保存できる', (): void => {
+    const block = blockService.createBlock(
+      [chromeTab('https://example.com/a', 'a', -1)],
+      createdAt,
+      0,
+    );
+
+    expect(block.groups).toBeUndefined();
+  });
+
+  // グループを使っていないブロックにキーを増やさない
+  // （storage.syncの8KB/item制限を圧迫しないため）
+  test('blockToJson グループのないブロックにgroupsキーを作らない', (): void => {
+    const json = blockService.blockToJson({
+      indexNum: 0,
+      createdAt: createdAt,
+      tabs: [{ url: 'https://example.com/a', title: 'a' }],
+    });
+
+    expect(JSON.parse(json)).not.toHaveProperty('groups');
+  });
+
+  test('blockToJson/jsonToBlock グループを往復できる', (): void => {
+    const block: model.Block = {
+      indexNum: 0,
+      createdAt: createdAt,
+      tabs: [
+        { url: 'https://example.com/a', title: 'a', group: 0 },
+        { url: 'https://example.com/b', title: 'b' },
+      ],
+      groups: [{ title: '調査中', color: 'blue' }],
+    };
+
+    expect(
+      blockService.jsonToBlock(blockService.blockToJson(block), 0),
+    ).toStrictEqual(block);
+  });
+
+  // 保存データは型検証がないので、壊れた値が入りうる
+  test.each([
+    ['範囲外の添字', 5],
+    ['負の数', -1],
+    ['小数', 0.5],
+    ['文字列', '0'],
+    ['null', null],
+  ])(
+    'jsonToBlock 参照先のないグループの添字(%s)は落とす',
+    (_name: string, group: unknown): void => {
+      const json = JSON.stringify({
+        created_at: createdAt.getTime(),
+        tabs: [{ url: 'https://example.com/a', title: 'a', group: group }],
+        groups: [{ title: '調査中', color: 'blue' }],
+      });
+
+      expect(blockService.jsonToBlock(json, 0).tabs).toStrictEqual([
+        { url: 'https://example.com/a', title: 'a' },
+      ]);
+    },
+  );
+
+  // 知らない色をそのままchrome.tabGroups.updateへ渡すと復元ごと失敗する
+  test('jsonToBlock 知らない色は既定値へ寄せる', (): void => {
+    const json = JSON.stringify({
+      created_at: createdAt.getTime(),
+      tabs: [{ url: 'https://example.com/a', title: 'a', group: 0 }],
+      groups: [{ title: '調査中', color: 'chartreuse' }],
+    });
+
+    expect(blockService.jsonToBlock(json, 0).groups).toStrictEqual([
+      { title: '調査中', color: 'grey' },
+    ]);
+  });
+
+  // 添字で参照する以上、途中の要素だけを捨てると後続の参照がずれる
+  test('jsonToBlock 壊れたグループがあっても並びと長さは保つ', (): void => {
+    const json = JSON.stringify({
+      created_at: createdAt.getTime(),
+      tabs: [{ url: 'https://example.com/a', title: 'a', group: 1 }],
+      groups: [null, { title: '調査中', color: 'blue' }],
+    });
+
+    const block = blockService.jsonToBlock(json, 0);
+    expect(block.groups).toStrictEqual([
+      { color: 'grey' },
+      { title: '調査中', color: 'blue' },
+    ]);
+    expect(block.tabs[0]!.group).toBe(1);
+  });
+
+  test('jsonToBlock groupsを持たない従来のデータはそのまま読める', (): void => {
+    const json =
+      '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"a"}]}';
+
+    const block = blockService.jsonToBlock(json, 0);
+    expect(block.groups).toBeUndefined();
+    expect(block.tabs).toStrictEqual([
+      { url: 'https://example.com/a', title: 'a' },
+    ]);
+  });
+
+  // v3の圧縮を通しても失われないこと。保存はdeflateBlock経由で行われる
+  test('deflateBlock/inflateJson グループを保ったまま往復できる', async (): Promise<void> => {
+    // 圧縮はafterEachでmockResetされるため、実装を戻してから通す
+    compressSpy.mockImplementationOnce(actualCompress);
+    decompressSpy.mockImplementationOnce(actualDecompress);
+    const block: model.Block = {
+      indexNum: 0,
+      createdAt: createdAt,
+      tabs: [{ url: 'https://example.com/a', title: 'a', group: 0 }],
+      groups: [{ title: '調査中', color: 'blue' }],
+    };
+
+    const stored = await blockService.deflateBlock(block);
+
+    await expect(blockService.inflateJson(stored, 0)).resolves.toStrictEqual(
+      block,
+    );
+  });
+});

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -20,20 +20,57 @@ export namespace blockService {
   // （v1のエクスポートはブロックの素の配列で版数を持たないため、ここには含めない）
   export const SUPPORTED_EXPORT_VERSIONS: readonly number[] = [2];
 
+  /**
+   * 保存するブロックを組み立てる。
+   * タブグループ(#191)は、渡されたグループのうち実際にタブが属しているものだけを
+   * ブロック側にまとめ、タブからは添字で参照する。名前と色をタブごとに複製するより
+   * 小さく、同じグループの実体が1つに定まる
+   * @param {chrome.tabs.Tab[]} tabs 保存するタブ
+   * @param {Date} createdAt 保存時刻
+   * @param {number} index ブロックのindex
+   * @param {chrome.tabGroups.TabGroup[]} tabGroups 保存時のタブグループ
+   * @return {model.Block} 保存するブロック
+   */
   export function createBlock(
     tabs: chrome.tabs.Tab[],
     createdAt: Date,
     index: number,
+    tabGroups: chrome.tabGroups.TabGroup[] = [],
   ): model.Block {
-    const blockTabs: model.Tab[] = tabs.map((tab) => ({
-      url: tab.url!,
-      title: tab.title!,
-    }));
+    // 実際にタブが属しているグループだけを、タブの並び順に拾う。
+    // 空のグループまで持つと、復元しても中身のないグループができる
+    const groupIndexes = new Map<number, number>();
+    const groups: model.TabGroup[] = [];
+    for (const tab of tabs) {
+      const tabGroup = tabGroups.find((group) => group.id === tab.groupId);
+      if (tabGroup == null || groupIndexes.has(tabGroup.id)) {
+        continue;
+      }
+      groupIndexes.set(tabGroup.id, groups.length);
+      groups.push({
+        // Chromeでは名前を付けずに色だけのグループを作れる
+        ...(tabGroup.title == null || tabGroup.title.length <= 0
+          ? {}
+          : { title: tabGroup.title }),
+        color: tabGroup.color,
+      });
+    }
+
+    const blockTabs: model.Tab[] = tabs.map((tab) => {
+      const groupIndex = groupIndexes.get(tab.groupId);
+      return {
+        url: tab.url!,
+        title: tab.title!,
+        // グループに属していないタブにキーを増やさない
+        ...(groupIndex == null ? {} : { group: groupIndex }),
+      };
+    });
 
     return {
       indexNum: index,
       createdAt: createdAt,
       tabs: blockTabs,
+      ...(groups.length <= 0 ? {} : { groups: groups }),
     };
   }
 
@@ -67,6 +104,10 @@ export namespace blockService {
       ...(block.locked === true ? { locked: true } : {}),
       // スターも同じ。付けていないブロックにキーを作らない
       ...(block.starred === true ? { starred: true } : {}),
+      // タブグループも同じ。グループを使っていないブロックにキーを作らない
+      ...(block.groups == null || block.groups.length <= 0
+        ? {}
+        : { groups: block.groups }),
     };
   }
 
@@ -118,6 +159,7 @@ export namespace blockService {
     title?: string;
     locked?: boolean;
     starred?: boolean;
+    groups?: model.TabGroup[];
     v?: number;
     d?: string;
   };
@@ -201,14 +243,101 @@ export namespace blockService {
     return starred === true ? { starred: true } : {};
   }
 
+  // chrome.tabGroups.Colorが取りうる値。知らない色をそのまま
+  // chrome.tabGroups.updateへ渡すと復元ごと失敗するため、読み込み時に弾く
+  const TAB_GROUP_COLORS: readonly string[] = [
+    'grey',
+    'blue',
+    'red',
+    'yellow',
+    'green',
+    'pink',
+    'purple',
+    'cyan',
+    'orange',
+  ];
+
+  // 色が壊れていたときの寄せ先。Chromeがグループ作成時に使う無彩色
+  const DEFAULT_TAB_GROUP_COLOR = 'grey';
+
+  /**
+   * 保存データのgroupsをタブグループの配列に変換する。
+   * titleやlockedと同じくインポートしたJSONには型の検証がないため、
+   * 配列でない・要素がオブジェクトでない場合はグループなしとして扱う
+   * @param {unknown} groups 保存データが持っていたgroups
+   * @return {object} groupsを持つオブジェクト。使っていなければ空オブジェクト
+   */
+  function blockGroupsField(groups: unknown): { groups?: model.TabGroup[] } {
+    if (!Array.isArray(groups) || groups.length <= 0) {
+      return {};
+    }
+    // 添字で参照する以上、途中の要素だけを捨てると後続の参照がずれる。
+    // 壊れた要素は既定値へ寄せて、配列の長さと並びは保つ
+    return {
+      groups: groups.map((group) => {
+        const title: unknown = (group as model.TabGroup | null)?.title;
+        const color: unknown = (group as model.TabGroup | null)?.color;
+        return {
+          ...(typeof title === 'string' && title.trim().length > 0
+            ? { title: title.trim() }
+            : {}),
+          color:
+            typeof color === 'string' && TAB_GROUP_COLORS.includes(color)
+              ? color
+              : DEFAULT_TAB_GROUP_COLOR,
+        };
+      }),
+    };
+  }
+
+  /**
+   * 保存データのタブを読む。jsonObjToBlockとjsonToBlockの両方から通す。
+   * かつてjsonToBlock側がタブを{url,title}に組み立て直しており、
+   * Tabにフィールドを足すと読み込みで消える形になっていた
+   * @param {model.Tab[]} tabs 保存データが持っていたtabs
+   * @param {model.TabGroup[] | undefined} groups 正規化済みのグループ
+   * @return {model.Tab[]} 復元したタブ
+   */
+  function toBlockTabs(
+    tabs: model.Tab[],
+    groups: model.TabGroup[] | undefined,
+  ): model.Tab[] {
+    const groupCount = groups?.length ?? 0;
+    return tabs.map((tab) => {
+      // 壊れたタブ（nullなど）はそのまま通す。作り直すと保存データの形が
+      // 変わってしまい、書き戻したときに別のデータになる
+      if (tab == null || typeof tab !== 'object') {
+        return tab;
+      }
+      const group: unknown = tab.group;
+      if (group === undefined) {
+        return tab;
+      }
+      if (
+        typeof group === 'number' &&
+        Number.isInteger(group) &&
+        group >= 0 &&
+        group < groupCount
+      ) {
+        return tab;
+      }
+      // 参照先のないグループを残すと、復元のときに存在しないグループを引く
+      const rest = { ...tab };
+      delete rest.group;
+      return rest;
+    });
+  }
+
   function jsonObjToBlock(object: BlockJson, index: number): model.Block {
+    const groupsField = blockGroupsField(object.groups);
     return {
       indexNum: index,
       createdAt: toCreatedAt(object.created_at),
-      tabs: object.tabs,
+      tabs: toBlockTabs(object.tabs, groupsField.groups),
       ...blockTitleField(object.title),
       ...blockLockedField(object.locked),
       ...blockStarredField(object.starred),
+      ...groupsField,
     };
   }
 
@@ -218,19 +347,16 @@ export namespace blockService {
 
   export function jsonToBlock(json: string, indexNum: number): model.Block {
     const js = JSON.parse(json) as BlockJson;
-
-    const tabs: model.Tab[] = js.tabs.map((jsonArr) => ({
-      url: jsonArr.url,
-      title: jsonArr.title,
-    }));
+    const groupsField = blockGroupsField(js.groups);
 
     return {
       indexNum: indexNum,
       createdAt: toCreatedAt(js.created_at),
-      tabs: tabs,
+      tabs: toBlockTabs(js.tabs, groupsField.groups),
       ...blockTitleField(js.title),
       ...blockLockedField(js.locked),
       ...blockStarredField(js.starred),
+      ...groupsField,
     };
   }
 

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -47,11 +47,12 @@ export namespace blockService {
         continue;
       }
       groupIndexes.set(tabGroup.id, groups.length);
+      // Chromeでは名前を付けずに色だけのグループを作れる。
+      // 名前の正規化は読み込み側と同じ規則に揃える（揃えないと、
+      // 保存直後の表示と読み直したあとの表示が食い違う）
+      const groupTitle = toDisplayTitle(tabGroup.title);
       groups.push({
-        // Chromeでは名前を付けずに色だけのグループを作れる
-        ...(tabGroup.title == null || tabGroup.title.length <= 0
-          ? {}
-          : { title: tabGroup.title }),
+        ...(groupTitle == null ? {} : { title: groupTitle }),
         color: tabGroup.color,
       });
     }
@@ -104,7 +105,10 @@ export namespace blockService {
       ...(block.locked === true ? { locked: true } : {}),
       // スターも同じ。付けていないブロックにキーを作らない
       ...(block.starred === true ? { starred: true } : {}),
-      // タブグループも同じ。グループを使っていないブロックにキーを作らない
+      // タブグループも同じ。グループを使っていないブロックにキーを作らない。
+      // タブを消してどのタブからも参照されなくなったグループは、あえて
+      // 残したまま書く。詰めると後続の添字がずれ、残ったタブが別のグループを
+      // 指してしまう（使われないグループのぶん保存データは大きいままになる）
       ...(block.groups == null || block.groups.length <= 0
         ? {}
         : { groups: block.groups }),
@@ -181,7 +185,8 @@ export namespace blockService {
   }
 
   /**
-   * 保存データのtitleをブロックの名前に変換する。
+   * 保存データのtitleを表示できる名前に変換する。ブロックの名前と
+   * タブグループの名前(#191)の両方から使う。
    * 型では文字列だが、インポートしたJSONには型の検証がないため実際には
    * 何でも入りうる。文字列以外をそのままblock.titleに持たせると
    * レンダリングで例外になりブロックごと破損カードに落ちるため、
@@ -191,7 +196,7 @@ export namespace blockService {
    * @param {unknown} title 保存データが持っていたtitle
    * @return {string | undefined} ブロックの名前。名前として扱えない値ならundefined
    */
-  function toBlockTitle(title: unknown): string | undefined {
+  function toDisplayTitle(title: unknown): string | undefined {
     if (typeof title === 'string') {
       // 空文字列と空白だけの文字列は名前なしと同じ扱いにして、デフォルトの
       // タブ数表示に戻す。空白だけの名前を通すと見出しが空のカードになり、
@@ -216,7 +221,7 @@ export namespace blockService {
    * @return {object} titleを持つオブジェクト。名前がなければ空オブジェクト
    */
   function blockTitleField(title: unknown): { title?: string } {
-    const blockTitle = toBlockTitle(title);
+    const blockTitle = toDisplayTitle(title);
     return blockTitle == null ? {} : { title: blockTitle };
   }
 
@@ -277,10 +282,11 @@ export namespace blockService {
       groups: groups.map((group) => {
         const title: unknown = (group as model.TabGroup | null)?.title;
         const color: unknown = (group as model.TabGroup | null)?.color;
+        // 名前の正規化はブロック名と同じ規則に揃える。同じ復元可能な情報を
+        // フィールドによって残したり捨てたりしない
+        const groupTitle = toDisplayTitle(title);
         return {
-          ...(typeof title === 'string' && title.trim().length > 0
-            ? { title: title.trim() }
-            : {}),
+          ...(groupTitle == null ? {} : { title: groupTitle }),
           color:
             typeof color === 'string' && TAB_GROUP_COLORS.includes(color)
               ? color

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -271,7 +271,10 @@ export namespace chromeService {
         return;
       }
       // tabIdsの型は空でないタプル。空配列を渡すとChromeも例外にするため、
-      // 上で弾いたうえでタプルとして渡す
+      // 上で弾いたうえでタプルとして渡す。
+      // createPropertiesを省くとタブのあるウィンドウにグループができる。
+      // 開く側(createTabs)もwindowIdを指定していないので現在のウィンドウで
+      // 揃う。片方だけウィンドウを指すようにすると食い違う
       const groupId = await chrome.tabs.group({
         tabIds: tabIds as [number, ...number[]],
       });

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -243,10 +243,60 @@ export namespace chromeService {
   }
 
   export namespace tab {
+    /**
+     * タブを開く。
+     * 作成したタブを返すのは、タブグループの再構成(#191)にidが要るため
+     * @param {chrome.tabs.CreateProperties} properties 開くタブ
+     * @return {Promise<chrome.tabs.Tab>} 開いたタブ
+     */
     export async function createTabs(
       properties: chrome.tabs.CreateProperties,
+    ): Promise<chrome.tabs.Tab> {
+      return chrome.tabs.create(properties);
+    }
+
+    /**
+     * 保存時のタブグループを、開いたタブに対して再構成する(#191)。
+     * 名前と色まで戻すのが目的なので、グループを作るところで終わらせず
+     * tabGroups.updateまで行う
+     * @param {number[]} tabIds まとめるタブのid
+     * @param {model.TabGroup} group 復元するグループの名前と色
+     * @return {Promise<void>}
+     */
+    export async function groupTabs(
+      tabIds: number[],
+      group: model.TabGroup,
     ): Promise<void> {
-      await chrome.tabs.create(properties);
+      if (tabIds.length <= 0) {
+        return;
+      }
+      // tabIdsの型は空でないタプル。空配列を渡すとChromeも例外にするため、
+      // 上で弾いたうえでタプルとして渡す
+      const groupId = await chrome.tabs.group({
+        tabIds: tabIds as [number, ...number[]],
+      });
+      await chrome.tabGroups.update(groupId, {
+        ...(group.title == null ? {} : { title: group.title }),
+        color: group.color as chrome.tabGroups.Color,
+      });
+    }
+
+    /**
+     * ウィンドウのタブグループを取得する。
+     * グループが取れないことと、タブを保存できないことは別なので、
+     * 失敗しても例外にせず空で返す（ここでthrowするとタブごと失う）
+     * @param {number} windowId 対象のウィンドウ
+     * @return {Promise<chrome.tabGroups.TabGroup[]>} タブグループ。失敗時は空
+     */
+    export async function queryTabGroups(
+      windowId: number,
+    ): Promise<chrome.tabGroups.TabGroup[]> {
+      try {
+        return await chrome.tabGroups.query({ windowId: windowId });
+      } catch (error) {
+        console.error(error);
+        return [];
+      }
     }
 
     async function closeTab(tab: chrome.tabs.Tab): Promise<void> {

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -12,6 +12,11 @@ import { model } from '../types/interface';
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+// createTabsは開いたタブを返す（タブグループの再構成にidが要る #191）。
+// テストではidだけが意味を持つので、最小限のTabを組み立てる
+const openedTab = (id = 1): chrome.tabs.Tab =>
+  ({ id: id, groupId: -1 }) as chrome.tabs.Tab;
+
 describe('App', (): void => {
   let localData: { [key: string]: string };
   let syncData: { [key: string]: string };
@@ -1256,7 +1261,7 @@ describe('App', (): void => {
       '{"v":2,"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"a"},null,{"url":"https://example.com/b","title":"b"}]}';
     const createTabsSpy = jest
       .spyOn(chromeService.tab, 'createTabs')
-      .mockResolvedValue(undefined);
+      .mockResolvedValue(openedTab());
     const setBlockSpy = jest
       .spyOn(chromeService.storage, 'setBlock')
       .mockResolvedValue(undefined);
@@ -1351,7 +1356,7 @@ describe('App', (): void => {
       '{"v":2,"created_at":1609556645678,"tabs":[null,{"url":"","title":"title-empty"}]}';
     const createTabsSpy = jest
       .spyOn(chromeService.tab, 'createTabs')
-      .mockResolvedValue(undefined);
+      .mockResolvedValue(openedTab());
     const setBlockSpy = jest
       .spyOn(chromeService.storage, 'setBlock')
       .mockResolvedValue(undefined);
@@ -1388,7 +1393,7 @@ describe('App', (): void => {
       '{"v":2,"created_at":1609556645678,"tabs":[{"url":"","title":"title-empty"},{"url":"https://example.com/ok","title":"title-ok"}]}';
     const createTabsSpy = jest
       .spyOn(chromeService.tab, 'createTabs')
-      .mockResolvedValue(undefined);
+      .mockResolvedValue(openedTab());
     const setBlockSpy = jest
       .spyOn(chromeService.storage, 'setBlock')
       .mockResolvedValue(undefined);
@@ -1975,8 +1980,8 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
       .mockResolvedValue(undefined);
     resolveCreateTabs = () => {};
     createTabsSpy = jest.spyOn(chromeService.tab, 'createTabs').mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolveCreateTabs = resolve;
+      new Promise<chrome.tabs.Tab>((resolve) => {
+        resolveCreateTabs = () => resolve(openedTab());
       }),
     );
     // ブロックの削除は確認を挟む(#252)。ここでの関心は書き込みの重なりなので
@@ -2046,7 +2051,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
   // ケース2: 2件の削除が重なる。ブロックを丸ごと書き戻すため、
   // 後から着地した側が相手の削除を打ち消し、消したタブが復活していた
   test('タブの削除が重なっても両方の削除が残る', async (): Promise<void> => {
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     // 1件目の書き込みを飛行中のままにして、着地する前に2件目を始めさせる
     let resolveFirstWrite: () => void = () => {};
     setBlockSpy.mockImplementationOnce(
@@ -2083,7 +2088,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
         ],
       },
     ]);
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     const resolvers: (() => void)[] = [];
     setBlockSpy.mockImplementation(
       () =>
@@ -2132,7 +2137,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
         ],
       },
     ]);
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     const resolvers: (() => void)[] = [];
     setBlockSpy.mockImplementation(
       () =>
@@ -2167,7 +2172,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
 
   // 失敗した書き込みでキューを止めると、以降そのブロックを操作できなくなる
   test('直前の書き込みが失敗しても次の書き込みは走る', async (): Promise<void> => {
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     let rejectFirstWrite: () => void = () => {};
     setBlockSpy.mockImplementationOnce(
       () =>
@@ -2192,7 +2197,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
   // 飛行中の書き込みを待たずにstorageを空にすると、あとから着地した
   // 書き込みが消したはずのブロックを書き戻し、画面が0件のまま復活する
   test('全データ削除は飛行中の書き込みが着地してから消す', async (): Promise<void> => {
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     let resolveWrite: () => void = () => {};
     setBlockSpy.mockImplementation(
       () =>
@@ -2235,7 +2240,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
   // allClearが着地するまでblocksRefは削除前のままなので、この間に始まった
   // 書き込みは「消えたブロックには書き戻さない」ガードをすり抜ける
   test('全データ削除の最中に始まった書き込みは書き戻さない', async (): Promise<void> => {
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     let resolveAllClear: () => void = () => {};
     const allClearSpy = jest
       .spyOn(chromeService.storage, 'allClear')
@@ -2290,7 +2295,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
 
     // 「すべてのリンクを開く」の書き戻しを待たせている間にtitle-aを消す
     await click('.all_tab_link');
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     await click('.tab_close', 0);
     await act(async () => {
       resolveCreateTabs();
@@ -2303,7 +2308,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
   // 壊れたブロックの削除も同じキューに乗せないと、飛行中の書き込みが
   // あとから着地して、消したブロックがstorageに戻る
   test('壊れたブロックの削除は飛行中の書き込みの後に行う', async (): Promise<void> => {
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     let resolveWrite: () => void = () => {};
     setBlockSpy.mockImplementation(
       () =>
@@ -2347,7 +2352,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
 
     // 2件目のリンクを開く。開き終わるまでの間に1件目を削除して並びをずらす
     await click('.tab_link', 1);
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     await click('.tab_close', 0);
     await act(async () => {
       resolveCreateTabs();

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -38,6 +38,11 @@ const savedBlock = (
 const savedIndexNum = (updateBlock: jest.Mock, callIndex = 0): number =>
   updateBlock.mock.calls[callIndex]![0] as number;
 
+// createTabsは開いたタブを返す（タブグループの再構成にidが要る #191）。
+// テストではidだけが意味を持つので、最小限のTabを組み立てる
+const openedTab = (id = 1): chrome.tabs.Tab =>
+  ({ id: id, groupId: -1 }) as chrome.tabs.Tab;
+
 describe('Block', (): void => {
   let container: HTMLDivElement;
   let root: Root;
@@ -608,8 +613,8 @@ describe('Block タブ操作と名前の編集の排他', (): void => {
     };
     resolveCreateTabs = () => {};
     createTabsSpy = jest.spyOn(chromeService.tab, 'createTabs').mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolveCreateTabs = resolve;
+      new Promise<chrome.tabs.Tab>((resolve) => {
+        resolveCreateTabs = () => resolve(openedTab());
       }),
     );
   });
@@ -771,7 +776,7 @@ describe('Block 編集のロック', (): void => {
     };
     createTabsSpy = jest
       .spyOn(chromeService.tab, 'createTabs')
-      .mockResolvedValue(undefined);
+      .mockResolvedValue(openedTab());
   });
 
   afterEach((): void => {
@@ -2076,7 +2081,7 @@ describe('Block ブロックの削除', (): void => {
   test('リンクを開いている最中でも押せる', async (): Promise<void> => {
     const createTabsSpy = jest
       .spyOn(chromeService.tab, 'createTabs')
-      .mockReturnValue(new Promise<void>(() => undefined));
+      .mockReturnValue(new Promise<chrome.tabs.Tab>(() => undefined));
 
     try {
       const updateBlock = jest.fn().mockResolvedValue(undefined);
@@ -2091,5 +2096,161 @@ describe('Block ブロックの削除', (): void => {
     } finally {
       createTabsSpy.mockRestore();
     }
+  });
+});
+
+// 保存したタブグループを「すべてのリンクを開く」で再構成する(#191)。
+// 個別のリンクではグループ化しない（1本だけのグループを作っても嬉しくない）
+describe('Block タブグループの復元', (): void => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let createTabsSpy: jest.SpyInstance;
+  let groupTabsSpy: jest.SpyInstance;
+  let errorLogSetSpy: jest.SpyInstance;
+
+  const grouped: model.Block = {
+    indexNum: 0,
+    createdAt: new Date('2021-01-02T03:04:05.678Z'),
+    tabs: [
+      { url: 'https://example.com/a', title: 'title-a', group: 0 },
+      { url: 'https://example.com/b', title: 'title-b' },
+      { url: 'https://example.com/c', title: 'title-c', group: 1 },
+      { url: 'https://example.com/d', title: 'title-d', group: 0 },
+    ],
+    groups: [
+      { title: '調査中', color: 'blue' },
+      { title: '読みもの', color: 'red' },
+    ],
+  };
+
+  const mount = async (block: model.Block = grouped): Promise<void> => {
+    renderedBlock = block;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Block
+          block={renderedBlock}
+          updateBlock={jest.fn().mockResolvedValue(undefined)}
+        />,
+      );
+    });
+  };
+
+  const click = async (selector: string, index = 0): Promise<void> => {
+    await act(async () => {
+      container.querySelectorAll<HTMLElement>(selector)[index]!.click();
+    });
+  };
+
+  beforeEach((): void => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    // 開いたタブのidは呼ばれた順に振る。どのタブがどのグループに入ったかを
+    // idで見分けられるようにする
+    let nextTabId = 100;
+    createTabsSpy = jest
+      .spyOn(chromeService.tab, 'createTabs')
+      .mockImplementation(() =>
+        Promise.resolve({ id: nextTabId++ } as chrome.tabs.Tab),
+      );
+    groupTabsSpy = jest
+      .spyOn(chromeService.tab, 'groupTabs')
+      .mockResolvedValue(undefined);
+    errorLogSetSpy = jest
+      .spyOn(chromeService.errorLog, 'set')
+      .mockResolvedValue(undefined);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      i18n: { getMessage: (key: string): string => key },
+    };
+  });
+
+  afterEach((): void => {
+    act(() => root.unmount());
+    container.remove();
+    createTabsSpy.mockRestore();
+    groupTabsSpy.mockRestore();
+    errorLogSetSpy.mockRestore();
+  });
+
+  test('すべてのリンクを開くとグループを名前と色ごと再構成する', async (): Promise<void> => {
+    await mount();
+
+    await click('.all_tab_link');
+
+    expect(groupTabsSpy).toHaveBeenCalledTimes(2);
+    // 同じグループのタブがまとまり、属していないタブは巻き込まない
+    expect(groupTabsSpy).toHaveBeenCalledWith([100, 103], {
+      title: '調査中',
+      color: 'blue',
+    });
+    expect(groupTabsSpy).toHaveBeenCalledWith([102], {
+      title: '読みもの',
+      color: 'red',
+    });
+  });
+
+  test('グループを持たないブロックではグループ化しない', async (): Promise<void> => {
+    await mount({
+      indexNum: 0,
+      createdAt: new Date('2021-01-02T03:04:05.678Z'),
+      tabs: [{ url: 'https://example.com/a', title: 'title-a' }],
+    });
+
+    await click('.all_tab_link');
+
+    expect(createTabsSpy).toHaveBeenCalledTimes(1);
+    expect(groupTabsSpy).not.toHaveBeenCalled();
+  });
+
+  // 1本だけのグループを作っても嬉しくない
+  test('個別のリンクを開いてもグループ化しない', async (): Promise<void> => {
+    await mount();
+
+    await click('.tab_link');
+
+    expect(createTabsSpy).toHaveBeenCalledTimes(1);
+    expect(groupTabsSpy).not.toHaveBeenCalled();
+  });
+
+  // タブは既に開かれているので、ここで中断すると一覧にも残って二重になる
+  test('グループ化に失敗しても書き戻しは行う', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    groupTabsSpy.mockRejectedValue(new Error('group failed'));
+    renderedBlock = grouped;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
+    });
+
+    await click('.all_tab_link');
+
+    expect(errorLogSetSpy).toHaveBeenCalled();
+    // 開いた4件すべてが一覧から消える
+    expect(savedBlock(updateBlock).tabs).toStrictEqual([]);
+  });
+
+  // 1つのグループの失敗で残りのグループまで諦めない
+  test('片方のグループ化が失敗しても他方は作る', async (): Promise<void> => {
+    groupTabsSpy.mockImplementation((tabIds: number[]) =>
+      tabIds.includes(102)
+        ? Promise.reject(new Error('group failed'))
+        : Promise.resolve(undefined),
+    );
+    await mount();
+
+    await click('.all_tab_link');
+
+    expect(groupTabsSpy).toHaveBeenCalledTimes(2);
+    expect(errorLogSetSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // ロック中は開くだけで一覧から消さないが、グループは戻す
+  test('ロック中でもグループを再構成する', async (): Promise<void> => {
+    await mount({ ...grouped, locked: true });
+
+    await click('.all_tab_link');
+
+    expect(groupTabsSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -2245,6 +2245,64 @@ describe('Block タブグループの復元', (): void => {
     expect(errorLogSetSpy).toHaveBeenCalledTimes(1);
   });
 
+  // モーダルは{title,url}しか知らない。差し替えにすると、名前を直しただけで
+  // タブがグループから外れる
+  test('タブを編集してもグループから外れない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    renderedBlock = grouped;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
+    });
+
+    await click('.tab_edit');
+    const input = container.querySelector<HTMLInputElement>('.edit-tab-title')!;
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    )!.set!;
+    await act(async () => {
+      setter.call(input, 'renamed-a');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      container.querySelector<HTMLElement>('.edit-tab-save')!.click();
+    });
+
+    expect(savedBlock(updateBlock).tabs[0]).toStrictEqual({
+      url: 'https://example.com/a',
+      title: 'renamed-a',
+      group: 0,
+    });
+  });
+
+  // 開けたタブが素のまま残ることまで巻き添えにする理由はない
+  test('1件開けなくても開けた分はグループ化する', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    let nextTabId = 100;
+    createTabsSpy.mockImplementation((properties: { url: string }) =>
+      properties.url === 'https://example.com/d'
+        ? Promise.reject(new Error('cannot open'))
+        : Promise.resolve({ id: nextTabId++ } as chrome.tabs.Tab),
+    );
+    renderedBlock = grouped;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
+    });
+
+    await click('.all_tab_link');
+
+    // 開けたタブだけでグループを作る
+    expect(groupTabsSpy).toHaveBeenCalledWith([100], {
+      title: '調査中',
+      color: 'blue',
+    });
+    // 1件でも開けなかったら1本も消さない（土台からの方針）
+    expect(updateBlock).not.toHaveBeenCalled();
+    expect(errorLogSetSpy).toHaveBeenCalled();
+  });
+
   // ロック中は開くだけで一覧から消さないが、グループは戻す
   test('ロック中でもグループを再構成する', async (): Promise<void> => {
     await mount({ ...grouped, locked: true });

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -269,7 +269,12 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
       if (at < 0) {
         throw new Error('edit target lost');
       }
-      return current.tabs.map((tab, i) => (i == at ? newTab : tab));
+      // モーダルは{title,url}しか知らないので、残りのフィールドは引き継ぐ。
+      // 差し替えにするとタブ側のフィールド（グループ #191）が
+      // 名前を直しただけで消える
+      return current.tabs.map((tab, i) =>
+        i == at ? { ...tab, ...newTab } : tab,
+      );
     }).then(() => {
       closeTabEdit();
     });
@@ -277,21 +282,33 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
 
   /**
    * タブをまとめて開き、保存時のタブグループを再構成する(#191)。
-   * グループ化に失敗しても解決する。タブは既に開かれているので、
-   * ここで中断すると呼び出し側が書き戻しをやめ、一覧にも残って二重になる
+   * グループ化そのものの失敗は握って解決する。タブは既に開かれているので、
+   * ここで中断すると呼び出し側が書き戻しをやめ、一覧にも残って二重になる。
+   * タブを開くのに失敗したときは、開けた分をグループ化してからrejectする。
+   * 「1件でも開けなかったら1本も消さない」のは呼び出し側の判断だが、
+   * 開けたタブが素のまま残ることまで巻き添えにする理由はない
    * @param {model.Tab[]} tabs 開くタブ
-   * @return {Promise<void>} すべて開き終わったら解決する
+   * @return {Promise<void>} 1件でも開けなかったらreject
    */
   const openTabsWithGroups = async (tabs: model.Tab[]): Promise<void> => {
-    const opened = await Promise.all(
+    const results = await Promise.allSettled(
       tabs.map((tab) =>
         chromeService.tab
           .createTabs({ url: tab.url, active: false })
           .then((created) => ({ tab: tab, id: created.id })),
       ),
     );
+    const opened = results.flatMap((result) =>
+      result.status === 'fulfilled' ? [result.value] : [],
+    );
+    const failed = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : [],
+    );
     const groups = block.groups;
     if (groups == null) {
+      if (failed.length > 0) {
+        throw failed[0];
+      }
       return;
     }
     // グループごとに開いたタブのidを集める。保存時に同じグループだった
@@ -318,6 +335,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
           .catch(console.error);
       }),
     );
+    if (failed.length > 0) {
+      throw failed[0];
+    }
   };
 
   const openAllTab = () => {

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -275,6 +275,51 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     });
   };
 
+  /**
+   * タブをまとめて開き、保存時のタブグループを再構成する(#191)。
+   * グループ化に失敗しても解決する。タブは既に開かれているので、
+   * ここで中断すると呼び出し側が書き戻しをやめ、一覧にも残って二重になる
+   * @param {model.Tab[]} tabs 開くタブ
+   * @return {Promise<void>} すべて開き終わったら解決する
+   */
+  const openTabsWithGroups = async (tabs: model.Tab[]): Promise<void> => {
+    const opened = await Promise.all(
+      tabs.map((tab) =>
+        chromeService.tab
+          .createTabs({ url: tab.url, active: false })
+          .then((created) => ({ tab: tab, id: created.id })),
+      ),
+    );
+    const groups = block.groups;
+    if (groups == null) {
+      return;
+    }
+    // グループごとに開いたタブのidを集める。保存時に同じグループだった
+    // タブだけがまとまるので、グループに属していなかったタブは素のまま残る
+    const tabIdsByGroup = new Map<number, number[]>();
+    for (const { tab, id } of opened) {
+      if (tab.group == null || id == null) {
+        continue;
+      }
+      const tabIds = tabIdsByGroup.get(tab.group) ?? [];
+      tabIds.push(id);
+      tabIdsByGroup.set(tab.group, tabIds);
+    }
+    // 1つのグループの失敗で残りのグループまで諦めない
+    await Promise.all(
+      [...tabIdsByGroup].map(([groupIndex, tabIds]) => {
+        const group = groups[groupIndex];
+        if (group == null) {
+          return Promise.resolve();
+        }
+        return chromeService.tab
+          .groupTabs(tabIds, group)
+          .catch((error) => chromeService.errorLog.set(error))
+          .catch(console.error);
+      }),
+    );
+  };
+
   const openAllTab = () => {
     // 壊れたタブを踏むとmapの途中で例外になり、残りのタブが開かれないまま
     // イベントハンドラの外へ抜けて通知もされないため、開ける分だけに絞る
@@ -286,11 +331,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     }
     if (locked) {
       // ロック中は開くだけで一覧から消さない
-      Promise.all(
-        openTabs.map((tab) =>
-          chromeService.tab.createTabs({ url: tab.url, active: false }),
-        ),
-      ).catch((error) => {
+      openTabsWithGroups(openTabs).catch((error) => {
         chromeService.errorLog.set(error).catch(console.error);
       });
       return;
@@ -301,11 +342,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     // 開けた分だけ消すと、失敗したタブだけが残ったのか
     // 全部残ったのかをユーザーが見分けられない
     trackTabWrite(
-      Promise.all(
-        openTabs.map((tab) =>
-          chromeService.tab.createTabs({ url: tab.url, active: false }),
-        ),
-      ).then(() => {
+      openTabsWithGroups(openTabs).then(() => {
         // 開いたタブだけを消す。開けなかったタブまでブロックごと消すと、
         // 一覧に見えていたタブが開かれもせず失われる
         removeTabs(openTabs).catch(() => {});
@@ -752,6 +789,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
               >
                 <Tab
                   tab={tab}
+                  group={
+                    tab.group == null ? undefined : block.groups?.[tab.group]
+                  }
                   deleteClick={() => deleteClick(index)}
                   editClick={() => startTabEdit(index)}
                   openLinkClick={() => openLink(index)}

--- a/src/js/components/tab.test.tsx
+++ b/src/js/components/tab.test.tsx
@@ -4,6 +4,7 @@
 import { act } from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { Tab } from './tab';
+import { model } from '../types/interface';
 
 // テスティングライブラリを介さず素のactを使うため必要
 (
@@ -14,12 +15,16 @@ describe('Tab', (): void => {
   let container: HTMLDivElement;
   let root: Root;
 
-  const mount = async (tab: { url: string; title: string }): Promise<void> => {
+  const mount = async (
+    tab: { url: string; title: string },
+    group?: model.TabGroup,
+  ): Promise<void> => {
     await act(async () => {
       root = createRoot(container);
       root.render(
         <Tab
           tab={tab}
+          group={group}
           deleteClick={jest.fn()}
           editClick={jest.fn()}
           openLinkClick={jest.fn()}
@@ -187,5 +192,34 @@ describe('Tab', (): void => {
     expect(link.getAttribute('href')).toBe('https://example.com/?a=1&b=2');
     expect(link.getAttribute('data-url')).toBe('https://example.com/?a=1&b=2');
     expect(link.getAttribute('data-title')).toBe('A & B');
+  });
+  // 保存時のタブグループ(#191)。「すべてのリンクを開く」で名前と色ごと
+  // 戻ることが一覧で分かるように出す
+  describe('タブグループ', (): void => {
+    const tab = { url: 'https://example.com/a', title: 'title-a' };
+
+    test('グループのないタブにはチップを出さない', async (): Promise<void> => {
+      await mount(tab);
+
+      expect(container.querySelector('.tab-group-chip')).toBeNull();
+    });
+
+    test('グループ名と色をチップで出す', async (): Promise<void> => {
+      await mount(tab, { title: '調査中', color: 'blue' });
+
+      const chip = container.querySelector('.tab-group-chip')!;
+      expect(chip.textContent).toBe('調査中');
+      // 色だけで区別させず、色は補助にとどめる
+      expect(chip.getAttribute('data-tab-group-color')).toBe('blue');
+    });
+
+    // Chromeでは名前を付けずに色だけのグループを作れる
+    test('名前のないグループはその旨を出す', async (): Promise<void> => {
+      await mount(tab, { color: 'red' });
+
+      const chip = container.querySelector('.tab-group-chip')!;
+      expect(chip.textContent).toBe('content_msg_tab_group_unnamed');
+      expect(chip.getAttribute('data-tab-group-color')).toBe('red');
+    });
   });
 });

--- a/src/js/components/tab.tsx
+++ b/src/js/components/tab.tsx
@@ -44,8 +44,10 @@ export const Tab: React.FC<TabProps> = (props) => {
           }
         >
           <span className="tab-group-dot" aria-hidden={true} />
-          {props.group.title ??
-            chrome.i18n.getMessage('content_msg_tab_group_unnamed')}
+          <span className="tab-group-name">
+            {props.group.title ??
+              chrome.i18n.getMessage('content_msg_tab_group_unnamed')}
+          </span>
         </span>
       )}
       <img

--- a/src/js/components/tab.tsx
+++ b/src/js/components/tab.tsx
@@ -4,6 +4,10 @@ import { util } from '../util';
 
 interface TabProps {
   tab: model.Tab;
+  // 保存時にこのタブが属していたタブグループ(#191)。
+  // グループに属していなかったタブと、タブグループを知らなかった頃に
+  // 保存されたタブではundefinedになる
+  group?: model.TabGroup;
   deleteClick: VoidFunction;
   editClick: VoidFunction;
   openLinkClick: VoidFunction;
@@ -27,6 +31,23 @@ export const Tab: React.FC<TabProps> = (props) => {
 
   return (
     <li className="tab-root-dom">
+      {/* 保存時のタブグループ。「すべてのリンクを開く」で名前と色ごと
+          戻ることが一覧で分かるように出す。名前を付けずに色だけの
+          グループも作れるので、名前がないときは色だけを見せる */}
+      {props.group == null ? null : (
+        <span
+          className="tab-group-chip"
+          data-tab-group-color={props.group.color}
+          title={
+            props.group.title ??
+            chrome.i18n.getMessage('content_msg_tab_group_unnamed')
+          }
+        >
+          <span className="tab-group-dot" aria-hidden={true} />
+          {props.group.title ??
+            chrome.i18n.getMessage('content_msg_tab_group_unnamed')}
+        </span>
+      )}
       <img
         src={`https://www.google.com/s2/favicons?domain=${encodeDomain}`}
         alt={props.tab.title}

--- a/src/js/types/interface.d.ts
+++ b/src/js/types/interface.d.ts
@@ -26,11 +26,35 @@ export namespace model {
      * undefinedになる
      */
     starred?: boolean;
+    /**
+     * 保存したときにタブが属していたChromeのタブグループ。
+     * タブ側はこの配列への添字(Tab.group)で参照する。名前と色をタブごとに
+     * 複製するより小さく、同じグループの実体が1つに定まる。
+     * グループを使っていないブロック（タブグループを知らなかった頃に
+     * 保存されたデータを含む）はundefinedになる
+     */
+    groups?: TabGroup[];
+  }
+
+  /**
+   * 保存したときのタブグループ。名前は付けていないことがある
+   * （Chromeでは色だけのグループを作れる）
+   */
+  interface TabGroup {
+    title?: string;
+    // chrome.tabGroups.Colorの値。知らない色が降ってきたら既定値へ寄せる
+    color: string;
   }
 
   interface Tab {
     url: string;
     title: string;
+    /**
+     * 属していたタブグループのBlock.groupsへの添字。
+     * グループに属していなかったタブと、タブグループを知らなかった頃に
+     * 保存されたタブはundefinedになる
+     */
+    group?: number;
   }
 
   /**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
   "minimum_chrome_version": "120",
   "description": "__MSG_Description__",
   "default_locale": "en",
-  "permissions": ["tabs", "storage", "contextMenus"],
+  "permissions": ["tabs", "tabGroups", "storage", "contextMenus"],
   "background": {
     "service_worker": "js/background.js"
   },


### PR DESCRIPTION
> [!NOTE]
> #264 → #262 → #261 → #260 の上に積んでいます。base は `worktree-issue-252-close-all-button`。下の PR がマージされたら順に base を切り替えます。

> [!IMPORTANT]
> **manifest に `tabGroups` permission を追加しています。** Chrome ウェブストアの再審査対象になります（データ収集の申告「なし」は変わりません）。

## 概要

タブをグループ化した状態でまとめると、**グループが全部解除されて格納されていた**。ストアレビュー（2024/03/19, Yuel 氏）が出典。保存時にグループの名前と色を記録し、「すべてのリンクを開く」で再構成する。

## 保存データの形

ブロック単位にグループの一覧を持ち、タブ側は添字で参照する。名前と色をタブごとに複製するより小さく、同じグループの実体が1つに定まる。

```json
{
  "created_at": 1609556645678,
  "tabs": [
    {"url": "...", "title": "...", "group": 0},
    {"url": "...", "title": "..."}
  ],
  "groups": [{"title": "調査中", "color": "blue"}]
}
```

- **スキーマ版数は上げない**。`title`(#195) / `locked`(#194) / `starred`(#196) と同じ扱い。上げると旧バージョンが sync 経由で降りてきたブロックを `UnsupportedVersionError` で一切表示できなくなる（`blockService.ts` の既存コメントの方針に従った）
- グループを使っていないブロックには `groups` キーを作らない。グループに属していないタブには `group` キーを作らない（`storage.sync` の 8KB/item 制限を圧迫しないため）
- タブが1つも属していないグループは保存しない（復元しても中身のないグループができる）

### 読み込み側の正規化

インポートした JSON には型の検証がないので、`blockTitleField` / `blockLockedField` / `blockStarredField` と同じ流儀で正規化する。

- **範囲外・非整数の `group` は落とす**。参照先のないグループを残すと、復元で存在しないグループを引く
- **知らない色は `grey` へ寄せる**。そのまま `chrome.tabGroups.update` へ渡すと復元ごと失敗する
- **壊れたグループがあっても配列の長さと並びは保つ**。添字で参照する以上、途中の要素を抜くと後続の参照がずれる

### 見つけた既存の穴

`jsonToBlock` はタブを `{url, title}` に**組み立て直して**いたため、`model.Tab` にフィールドを足すと読み込みで消える形になっていた。`jsonObjToBlock` と共通のヘルパ（`toBlockTabs`）に寄せた。ヘルパは**非破壊**で、壊れたタブ（`null` など）はそのまま通す — 作り直すと `null` が `{}` になって保存データの形が変わってしまう。

## 保存経路

`background.ts` の `saveWindowTabs` で `chrome.tabGroups.query({windowId})` を1回だけ引き、`blockService.createBlock` に渡す。

**タブグループの取得に失敗しても保存は続ける。** グループが取れないことと、タブを保存できないことは別で、ここで止めるとタブごと失う。

## 復元経路

グループ化にはタブの id が要るので、`chromeService.tab.createTabs` が開いたタブを返すようにした（既存の呼び出し側とテストのモックが影響を受ける）。

- **「すべてのリンクを開く」だけ**でグループを再構成する。個別のリンクではグループ化しない（1本だけのグループを作っても嬉しくない）
- **グループ化の失敗は書き戻しを止めない**。タブは既に開かれているので、ここで中断すると一覧にも残って二重になる
- **1つのグループの失敗で残りのグループまで諦めない**
- ロック中は開くだけで一覧から消さないが、グループは戻す

## 表示

各タブの先頭にグループ名と色のチップを出す。保存・復元されていることが一覧で分かるようにするための最小限。**色だけで区別させると色覚特性によっては読み取れない**ため、名前も併記して色は補助にとどめた。Chrome では名前を付けずに色だけのグループを作れるので、その場合は「名前のないグループ」と出す。

## テスト

**26件追加**（343 → 369件）。

- `blockService.test.ts`: グループの組み立て / 空のグループを持たない / `groups` キーを作らない / 往復（`blockToJson`↔`jsonToBlock`、v3 の deflate 経由も）/ 壊れた添字5パターン / 知らない色 / 壊れたグループでも並びを保つ / 従来データがそのまま読める
- `background.test.ts`: グループの名前と色を保存する / 取得に失敗してもタブは保存する
- `block.test.tsx`: グループを再構成する / グループなしでは呼ばない / 個別のリンクでは呼ばない / 失敗しても書き戻す / 片方が失敗しても他方は作る / ロック中でも再構成する
- `tab.test.tsx`: チップの表示（なし / 名前あり / 名前なし）

以下の変異でテストが落ちることを確認済み: `jsonToBlock` で `group` を落とす（旧実装の再現）/ 添字の範囲チェックを外す / 個別のリンクでもグループ化する / グループ化の失敗を握らない。

`npx tsc --noEmit` / `npm run format:check` / `npm run lint` / `npm test`（14 suites, 369 tests）/ `npm run build` すべて通過。

## 手動確認（未実施 / レビュー時にお願いしたい点）

1. **保存**: タブを2つのグループ（名前・色違い）に分けてアイコンを押す → 一覧のカードにグループ名と色のチップが出ること
2. **復元**: そのカードの「すべてのリンクを開く」→ 元の名前・色でグループが再構成され、グループ外のタブが巻き込まれないこと
3. **個別**: 個別のリンクを開いてもグループが作られないこと
4. **旧データ**: この機能より前に保存したブロックが今までどおり開けること
5. **チップの見た目**: 長いグループ名でタブのリンクが押し出されないか（`max-width: 12rem` + 省略記号）

Closes #191
