### PR TITLE
npm audit fix: nanoid を 3.3.18 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7296,9 +7296,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## 概要

`npm audit` で high の脆弱性が 1 件報告されていたため対応した。

- **nanoid < 3.3.18** — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)
  custom generators に `size = 0` を渡すと無限ループする
- `css-loader` → `postcss` 経由の推移的依存（devDependencies のみ、拡張機能のバンドルには含まれない）

## 変更内容

`package-lock.json` の nanoid を 3.3.16 → 3.3.18 に更新。`package.json` に変更はない。

なお `npm audit fix` は `@eslint/js@^10` と `eslint@^9` の既存の peer 依存衝突で ERESOLVE となり実行できなかったため、`npm update nanoid` で lockfile のみを更新している。

## 確認したこと

- `npm audit` → `found 0 vulnerabilities`
- `npm test` → 14 suites / 347 tests すべて pass
- `npm run lint` → エラーなし
- `webpack --config webpack.prod.js` → ビルド成功
