### PR TITLE
既存のブロックへ手動でリンクを足せるようにする

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -24,6 +24,9 @@
   "content_msg_all_tab_open": {
     "message": "Open all links"
   },
+  "content_msg_tab_group_unnamed": {
+    "message": "Unnamed group"
+  },
   "content_msg_delete_block": {
     "message": "Delete block"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -95,6 +95,15 @@
   "content_msg_delete_tab": {
     "message": "Delete"
   },
+  "content_msg_add_tab": {
+    "message": "Add link"
+  },
+  "content_msg_add_tab_heading": {
+    "message": "Add link"
+  },
+  "content_msg_add_tab_save": {
+    "message": "Add"
+  },
   "content_msg_edit_tab_heading": {
     "message": "Edit link"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -98,9 +98,6 @@
   "content_msg_add_tab": {
     "message": "Add link"
   },
-  "content_msg_add_tab_heading": {
-    "message": "Add link"
-  },
   "content_msg_add_tab_save": {
     "message": "Add"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -95,6 +95,15 @@
   "content_msg_delete_tab": {
     "message": "削除"
   },
+  "content_msg_add_tab": {
+    "message": "リンクを追加"
+  },
+  "content_msg_add_tab_heading": {
+    "message": "リンクを追加"
+  },
+  "content_msg_add_tab_save": {
+    "message": "追加"
+  },
   "content_msg_edit_tab_heading": {
     "message": "リンクを編集"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -98,9 +98,6 @@
   "content_msg_add_tab": {
     "message": "リンクを追加"
   },
-  "content_msg_add_tab_heading": {
-    "message": "リンクを追加"
-  },
   "content_msg_add_tab_save": {
     "message": "追加"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -24,6 +24,9 @@
   "content_msg_all_tab_open": {
     "message": "すべてのリンクを開く"
   },
+  "content_msg_tab_group_unnamed": {
+    "message": "名前のないグループ"
+  },
   "content_msg_delete_block": {
     "message": "ブロックを削除"
   },

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -341,3 +341,75 @@
 .uk-card-body[inert] {
   opacity: 0.5;
 }
+
+/*
+ * 保存時のタブグループ (#191)
+ *
+ * 「すべてのリンクを開く」で名前と色ごと戻ることが一覧で分かるように、
+ * タブ1行の先頭へ小さく出す。色だけで区別させると色覚特性によっては
+ * 読み取れないため、名前も併記して色は補助にとどめる。
+ * 色の値はChromeのタブグループが取りうる9色で、
+ * Chromeのグループ表示に寄せた彩度の低い色を使う。
+ */
+.tab-group-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: 6px;
+  padding: 0 6px;
+  border-radius: 8px;
+  background-color: #f0f0f0;
+  color: #333;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  /* 長いグループ名でタブのリンクが押し出されないようにする */
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tab-group-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  /* 知らない色が保存データに入っていても、点が消えて詰まって見えないようにする */
+  background-color: #5f6368;
+}
+
+.tab-group-chip[data-tab-group-color='grey'] .tab-group-dot {
+  background-color: #5f6368;
+}
+
+.tab-group-chip[data-tab-group-color='blue'] .tab-group-dot {
+  background-color: #1a73e8;
+}
+
+.tab-group-chip[data-tab-group-color='red'] .tab-group-dot {
+  background-color: #d93025;
+}
+
+.tab-group-chip[data-tab-group-color='yellow'] .tab-group-dot {
+  background-color: #f9ab00;
+}
+
+.tab-group-chip[data-tab-group-color='green'] .tab-group-dot {
+  background-color: #1e8e3e;
+}
+
+.tab-group-chip[data-tab-group-color='pink'] .tab-group-dot {
+  background-color: #d01884;
+}
+
+.tab-group-chip[data-tab-group-color='purple'] .tab-group-dot {
+  background-color: #9334e6;
+}
+
+.tab-group-chip[data-tab-group-color='cyan'] .tab-group-dot {
+  background-color: #007b83;
+}
+
+.tab-group-chip[data-tab-group-color='orange'] .tab-group-dot {
+  background-color: #fa903e;
+}

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -318,6 +318,7 @@
  */
 .tab_edit[aria-disabled='true'],
 .tab_close[aria-disabled='true'],
+.add_tab[aria-disabled='true'],
 .block-delete[aria-disabled='true'] {
   opacity: 0.5;
   cursor: default;
@@ -326,6 +327,7 @@
 /* uk-linkのhoverが残ると、押せないのに色が変わって押せるように見える */
 .tab_edit[aria-disabled='true']:hover,
 .tab_close[aria-disabled='true']:hover,
+.add_tab[aria-disabled='true']:hover,
 .block-delete[aria-disabled='true']:hover {
   color: inherit;
   text-decoration: none;
@@ -421,4 +423,19 @@
 
 .tab-group-chip[data-tab-group-color='orange'] .tab-group-dot {
   background-color: #fa903e;
+}
+
+/*
+ * 手動でリンクを足す導線 (#253)
+ *
+ * 隣の「すべてのリンクを開く」と同じ行に並ぶので見た目はリンクに揃えるが、
+ * 要素はbuttonにする（spanだとキーボードのタブ順に入らない）。
+ * ブラウザ既定のボタンの装飾を落として、uk-linkの見た目だけを借りる
+ */
+.add_tab {
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  cursor: pointer;
 }

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -364,7 +364,16 @@
   line-height: 1.6;
   /* 長いグループ名でタブのリンクが押し出されないようにする */
   max-width: 12rem;
+}
+
+/*
+ * 省略記号はブロックコンテナにしか効かないため、inline-flexのチップ自体では
+ * なく中の要素に当てる。チップに書くと、はみ出した名前が
+ * 「…」なしでグリフの途中から切れて、途中までが本当の名前に見える
+ */
+.tab-group-name {
   overflow: hidden;
+  min-width: 0;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/src/js/background.test.ts
+++ b/src/js/background.test.ts
@@ -11,6 +11,8 @@ describe('background action.onClicked', (): void => {
   // ユーザーが別のウィンドウへ移っても、保存も終了もこのウィンドウを指す
   const CURRENT_WINDOW_ID = 1;
   let openedTabs: chrome.tabs.Tab[];
+  // 保存時のタブグループ(#191)。queryTabGroupsが投げる状況も作れるようにする
+  let tabGroups: chrome.tabGroups.TabGroup[] | Error;
   let clickAction: (tab: chrome.tabs.Tab) => void;
   const create = jest.fn();
   const update = jest.fn();
@@ -29,8 +31,15 @@ describe('background action.onClicked', (): void => {
     id: number,
     url: string,
     windowId: number = CURRENT_WINDOW_ID,
+    groupId = -1,
   ): chrome.tabs.Tab =>
-    ({ id: id, windowId: windowId, url: url, title: url }) as chrome.tabs.Tab;
+    ({
+      id: id,
+      windowId: windowId,
+      url: url,
+      title: url,
+      groupId: groupId,
+    }) as chrome.tabs.Tab;
 
   /**
    * chromeのAPIを差し替えたうえでbackgroundを読み込み、
@@ -73,6 +82,12 @@ describe('background action.onClicked', (): void => {
         remove: remove,
       },
       windows: { update: jest.fn() },
+      tabGroups: {
+        query: (): Promise<chrome.tabGroups.TabGroup[]> =>
+          tabGroups instanceof Error
+            ? Promise.reject(tabGroups)
+            : Promise.resolve(tabGroups),
+      },
     };
     const { chromeService } = await import('./chromeService');
     jest.spyOn(chromeService.storage, 'getNextBlockIndex').mockResolvedValue(3);
@@ -93,6 +108,7 @@ describe('background action.onClicked', (): void => {
 
   beforeEach((): void => {
     openedTabs = [];
+    tabGroups = [];
     create.mockClear();
     update.mockClear();
     move.mockClear();
@@ -112,6 +128,59 @@ describe('background action.onClicked', (): void => {
       await Promise.resolve();
     }
   };
+
+  // Chromeのタブグループを保持したまま保存する(#191)
+  test('タブグループの名前と色も保存する', async (): Promise<void> => {
+    openedTabs = [
+      tab(1, 'https://example.com/a', CURRENT_WINDOW_ID, 7),
+      tab(2, 'https://example.com/b'),
+    ];
+    tabGroups = [
+      { id: 7, title: '調査中', color: 'blue' } as chrome.tabGroups.TabGroup,
+    ];
+    await loadBackground();
+
+    await click();
+
+    expect(setBlock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        groups: [{ title: '調査中', color: 'blue' }],
+        tabs: [
+          expect.objectContaining({ url: 'https://example.com/a', group: 0 }),
+          // グループに属していないタブにキーを増やさない
+          { url: 'https://example.com/b', title: 'https://example.com/b' },
+        ],
+      }),
+    );
+  });
+
+  // グループが取れないことと、タブを保存できないことは別。
+  // ここで止めるとタブごと失う
+  test('タブグループの取得に失敗してもタブは保存する', async (): Promise<void> => {
+    openedTabs = [tab(1, 'https://example.com/a', CURRENT_WINDOW_ID, 7)];
+    tabGroups = new Error('no permission');
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    await loadBackground();
+
+    try {
+      await click();
+
+      expect(setBlock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tabs: [
+            { url: 'https://example.com/a', title: 'https://example.com/a' },
+          ],
+        }),
+      );
+      expect(setBlock.mock.calls[0][0].groups).toBeUndefined();
+      // 閉じる・tabsページを開くところまで従来どおり進む
+      expect(remove).toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
 
   test('現在のウィンドウの全タブを保存して閉じ、tabsページを開く', async (): Promise<void> => {
     openedTabs = [

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -34,7 +34,15 @@ async function saveWindowTabs(windowId: number): Promise<void> {
   // 空のブロックを書くとindexだけ進んで無駄な欠番が増えるため、
   // tabsページへの切り替えだけを行う
   if (currentTabs.length > 0) {
-    const block = blockService.createBlock(currentTabs, new Date(), nextIndex);
+    // タブグループの名前と色を保存に含める(#191)。取得に失敗しても
+    // グループなしとして保存を続ける（ここで止めるとタブごと失う）
+    const tabGroups = await chromeService.tab.queryTabGroups(windowId);
+    const block = blockService.createBlock(
+      currentTabs,
+      new Date(),
+      nextIndex,
+      tabGroups,
+    );
     await chromeService.storage.setBlock(block);
     await chromeService.storage.setTabLength(nextIndex + 1);
   }

--- a/src/js/blockService.test.ts
+++ b/src/js/blockService.test.ts
@@ -1276,6 +1276,95 @@ describe('blockService タブグループ', (): void => {
     expect(block.tabs[0]!.group).toBe(1);
   });
 
+  // groupsが配列でない・要素が壊れている場合。インポートしたJSONには
+  // 型の検証がないので何でも入りうる
+  test.each([
+    ['文字列', '"oops"'],
+    ['オブジェクト', '{"a":1}'],
+    ['数値', '3'],
+    ['空配列', '[]'],
+  ])(
+    'jsonToBlock groupsが配列でない(%s)ときはグループなしとして読む',
+    (_name: string, groupsJson: string): void => {
+      const json = `{"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"a","group":0}],"groups":${groupsJson}}`;
+
+      const block = blockService.jsonToBlock(json, 0);
+      expect(block.groups).toBeUndefined();
+      // 参照先がないので添字も落ちる
+      expect(block.tabs).toStrictEqual([
+        { url: 'https://example.com/a', title: 'a' },
+      ]);
+    },
+  );
+
+  // 同じ復元可能な情報をフィールドによって残したり捨てたりしない
+  // （ブロック名は数値を文字列として残す）
+  test('jsonToBlock 数値のグループ名は文字列として残す', (): void => {
+    const json =
+      '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"a","group":0}],"groups":[{"title":2026,"color":"blue"}]}';
+
+    expect(blockService.jsonToBlock(json, 0).groups).toStrictEqual([
+      { title: '2026', color: 'blue' },
+    ]);
+  });
+
+  // jsonObjToBlockとjsonToBlockが同じヘルパを共有していることの担保。
+  // 片方だけ検証していると、共有が崩れたときに気づけない
+  test('inflateJson(v2の非圧縮)でも同じように正規化する', async (): Promise<void> => {
+    const stored = JSON.stringify({
+      v: 2,
+      created_at: 1609556645678,
+      tabs: [
+        { url: 'https://example.com/a', title: 'a', group: 9 },
+        { url: 'https://example.com/b', title: 'b', group: 0 },
+      ],
+      groups: [{ title: '  調査中  ', color: 'chartreuse' }],
+    });
+
+    const block = await blockService.inflateJson(stored, 0);
+    expect(block.groups).toStrictEqual([{ title: '調査中', color: 'grey' }]);
+    expect(block.tabs).toStrictEqual([
+      // 範囲外の添字は落ちる
+      { url: 'https://example.com/a', title: 'a' },
+      { url: 'https://example.com/b', title: 'b', group: 0 },
+    ]);
+  });
+
+  // 読み込みで元のオブジェクトを書き換えると、呼び出し側が持っている
+  // 参照の中身が変わる
+  test('jsonToBlock 入力のタブを書き換えない', (): void => {
+    const tabs = [{ url: 'https://example.com/a', title: 'a', group: 9 }];
+    const json = JSON.stringify({ created_at: 1609556645678, tabs: tabs });
+
+    blockService.jsonToBlock(json, 0);
+
+    expect(tabs[0]!.group).toBe(9);
+  });
+
+  // v1のzlib経路もjsonToBlockを通る。かつてタブを{url,title}に
+  // 組み立て直しており、nullのタブでTypeErrorになってブロックごと落ちていた
+  test('jsonToBlock 壊れたタブはそのまま通す', (): void => {
+    const json =
+      '{"created_at":1609556645678,"tabs":[null,{"url":"https://example.com/a","title":"a"}]}';
+
+    expect(blockService.jsonToBlock(json, 0).tabs).toStrictEqual([
+      null,
+      { url: 'https://example.com/a', title: 'a' },
+    ]);
+  });
+
+  // 同じidのグループが複数あっても、最初の1件だけを採る
+  test('createBlock 同じidのグループが重複していても1件にまとめる', (): void => {
+    const block = blockService.createBlock(
+      [chromeTab('https://example.com/a', 'a', 7)],
+      createdAt,
+      0,
+      [chromeGroup(7, '先勝ち', 'blue'), chromeGroup(7, '後', 'red')],
+    );
+
+    expect(block.groups).toStrictEqual([{ title: '先勝ち', color: 'blue' }]);
+  });
+
   test('jsonToBlock groupsを持たない従来のデータはそのまま読める', (): void => {
     const json =
       '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"a"}]}';

--- a/src/js/blockService.test.ts
+++ b/src/js/blockService.test.ts
@@ -1119,3 +1119,190 @@ describe('blockService import/export', (): void => {
     },
   );
 });
+
+// Chromeのタブグループを保持したまま保存・復元する(#191)。
+// グループはブロック単位に持ち、タブからは添字で参照する
+describe('blockService タブグループ', (): void => {
+  const chromeTab = (
+    url: string,
+    title: string,
+    groupId: number,
+  ): chrome.tabs.Tab =>
+    ({ url: url, title: title, groupId: groupId }) as chrome.tabs.Tab;
+
+  const chromeGroup = (
+    id: number,
+    title: string | undefined,
+    color: string,
+  ): chrome.tabGroups.TabGroup =>
+    ({ id: id, title: title, color: color }) as chrome.tabGroups.TabGroup;
+
+  const createdAt = new Date('2021-01-02T03:04:05.678Z');
+
+  test('createBlock グループの名前と色をブロックに持ち、タブは添字で指す', (): void => {
+    const block = blockService.createBlock(
+      [
+        chromeTab('https://example.com/a', 'a', 7),
+        chromeTab('https://example.com/b', 'b', -1),
+        chromeTab('https://example.com/c', 'c', 7),
+      ],
+      createdAt,
+      0,
+      [chromeGroup(7, '調査中', 'blue')],
+    );
+
+    expect(block.groups).toStrictEqual([{ title: '調査中', color: 'blue' }]);
+    expect(block.tabs).toStrictEqual([
+      { url: 'https://example.com/a', title: 'a', group: 0 },
+      // グループに属していないタブにキーを増やさない
+      { url: 'https://example.com/b', title: 'b' },
+      { url: 'https://example.com/c', title: 'c', group: 0 },
+    ]);
+  });
+
+  // Chromeでは名前を付けずに色だけのグループを作れる
+  test('createBlock 名前のないグループは色だけを持つ', (): void => {
+    const block = blockService.createBlock(
+      [chromeTab('https://example.com/a', 'a', 7)],
+      createdAt,
+      0,
+      [chromeGroup(7, '', 'red')],
+    );
+
+    expect(block.groups).toStrictEqual([{ color: 'red' }]);
+  });
+
+  // 空のグループまで持つと、復元しても中身のないグループができる
+  test('createBlock タブが属していないグループは持たない', (): void => {
+    const block = blockService.createBlock(
+      [chromeTab('https://example.com/a', 'a', -1)],
+      createdAt,
+      0,
+      [chromeGroup(7, '使っていない', 'blue')],
+    );
+
+    expect(block.groups).toBeUndefined();
+    expect(block.tabs).toStrictEqual([
+      { url: 'https://example.com/a', title: 'a' },
+    ]);
+  });
+
+  test('createBlock グループを渡さなくても従来どおり保存できる', (): void => {
+    const block = blockService.createBlock(
+      [chromeTab('https://example.com/a', 'a', -1)],
+      createdAt,
+      0,
+    );
+
+    expect(block.groups).toBeUndefined();
+  });
+
+  // グループを使っていないブロックにキーを増やさない
+  // （storage.syncの8KB/item制限を圧迫しないため）
+  test('blockToJson グループのないブロックにgroupsキーを作らない', (): void => {
+    const json = blockService.blockToJson({
+      indexNum: 0,
+      createdAt: createdAt,
+      tabs: [{ url: 'https://example.com/a', title: 'a' }],
+    });
+
+    expect(JSON.parse(json)).not.toHaveProperty('groups');
+  });
+
+  test('blockToJson/jsonToBlock グループを往復できる', (): void => {
+    const block: model.Block = {
+      indexNum: 0,
+      createdAt: createdAt,
+      tabs: [
+        { url: 'https://example.com/a', title: 'a', group: 0 },
+        { url: 'https://example.com/b', title: 'b' },
+      ],
+      groups: [{ title: '調査中', color: 'blue' }],
+    };
+
+    expect(
+      blockService.jsonToBlock(blockService.blockToJson(block), 0),
+    ).toStrictEqual(block);
+  });
+
+  // 保存データは型検証がないので、壊れた値が入りうる
+  test.each([
+    ['範囲外の添字', 5],
+    ['負の数', -1],
+    ['小数', 0.5],
+    ['文字列', '0'],
+    ['null', null],
+  ])(
+    'jsonToBlock 参照先のないグループの添字(%s)は落とす',
+    (_name: string, group: unknown): void => {
+      const json = JSON.stringify({
+        created_at: createdAt.getTime(),
+        tabs: [{ url: 'https://example.com/a', title: 'a', group: group }],
+        groups: [{ title: '調査中', color: 'blue' }],
+      });
+
+      expect(blockService.jsonToBlock(json, 0).tabs).toStrictEqual([
+        { url: 'https://example.com/a', title: 'a' },
+      ]);
+    },
+  );
+
+  // 知らない色をそのままchrome.tabGroups.updateへ渡すと復元ごと失敗する
+  test('jsonToBlock 知らない色は既定値へ寄せる', (): void => {
+    const json = JSON.stringify({
+      created_at: createdAt.getTime(),
+      tabs: [{ url: 'https://example.com/a', title: 'a', group: 0 }],
+      groups: [{ title: '調査中', color: 'chartreuse' }],
+    });
+
+    expect(blockService.jsonToBlock(json, 0).groups).toStrictEqual([
+      { title: '調査中', color: 'grey' },
+    ]);
+  });
+
+  // 添字で参照する以上、途中の要素だけを捨てると後続の参照がずれる
+  test('jsonToBlock 壊れたグループがあっても並びと長さは保つ', (): void => {
+    const json = JSON.stringify({
+      created_at: createdAt.getTime(),
+      tabs: [{ url: 'https://example.com/a', title: 'a', group: 1 }],
+      groups: [null, { title: '調査中', color: 'blue' }],
+    });
+
+    const block = blockService.jsonToBlock(json, 0);
+    expect(block.groups).toStrictEqual([
+      { color: 'grey' },
+      { title: '調査中', color: 'blue' },
+    ]);
+    expect(block.tabs[0]!.group).toBe(1);
+  });
+
+  test('jsonToBlock groupsを持たない従来のデータはそのまま読める', (): void => {
+    const json =
+      '{"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"a"}]}';
+
+    const block = blockService.jsonToBlock(json, 0);
+    expect(block.groups).toBeUndefined();
+    expect(block.tabs).toStrictEqual([
+      { url: 'https://example.com/a', title: 'a' },
+    ]);
+  });
+
+  // v3の圧縮を通しても失われないこと。保存はdeflateBlock経由で行われる
+  test('deflateBlock/inflateJson グループを保ったまま往復できる', async (): Promise<void> => {
+    // 圧縮はafterEachでmockResetされるため、実装を戻してから通す
+    compressSpy.mockImplementationOnce(actualCompress);
+    decompressSpy.mockImplementationOnce(actualDecompress);
+    const block: model.Block = {
+      indexNum: 0,
+      createdAt: createdAt,
+      tabs: [{ url: 'https://example.com/a', title: 'a', group: 0 }],
+      groups: [{ title: '調査中', color: 'blue' }],
+    };
+
+    const stored = await blockService.deflateBlock(block);
+
+    await expect(blockService.inflateJson(stored, 0)).resolves.toStrictEqual(
+      block,
+    );
+  });
+});

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -20,20 +20,57 @@ export namespace blockService {
   // （v1のエクスポートはブロックの素の配列で版数を持たないため、ここには含めない）
   export const SUPPORTED_EXPORT_VERSIONS: readonly number[] = [2];
 
+  /**
+   * 保存するブロックを組み立てる。
+   * タブグループ(#191)は、渡されたグループのうち実際にタブが属しているものだけを
+   * ブロック側にまとめ、タブからは添字で参照する。名前と色をタブごとに複製するより
+   * 小さく、同じグループの実体が1つに定まる
+   * @param {chrome.tabs.Tab[]} tabs 保存するタブ
+   * @param {Date} createdAt 保存時刻
+   * @param {number} index ブロックのindex
+   * @param {chrome.tabGroups.TabGroup[]} tabGroups 保存時のタブグループ
+   * @return {model.Block} 保存するブロック
+   */
   export function createBlock(
     tabs: chrome.tabs.Tab[],
     createdAt: Date,
     index: number,
+    tabGroups: chrome.tabGroups.TabGroup[] = [],
   ): model.Block {
-    const blockTabs: model.Tab[] = tabs.map((tab) => ({
-      url: tab.url!,
-      title: tab.title!,
-    }));
+    // 実際にタブが属しているグループだけを、タブの並び順に拾う。
+    // 空のグループまで持つと、復元しても中身のないグループができる
+    const groupIndexes = new Map<number, number>();
+    const groups: model.TabGroup[] = [];
+    for (const tab of tabs) {
+      const tabGroup = tabGroups.find((group) => group.id === tab.groupId);
+      if (tabGroup == null || groupIndexes.has(tabGroup.id)) {
+        continue;
+      }
+      groupIndexes.set(tabGroup.id, groups.length);
+      groups.push({
+        // Chromeでは名前を付けずに色だけのグループを作れる
+        ...(tabGroup.title == null || tabGroup.title.length <= 0
+          ? {}
+          : { title: tabGroup.title }),
+        color: tabGroup.color,
+      });
+    }
+
+    const blockTabs: model.Tab[] = tabs.map((tab) => {
+      const groupIndex = groupIndexes.get(tab.groupId);
+      return {
+        url: tab.url!,
+        title: tab.title!,
+        // グループに属していないタブにキーを増やさない
+        ...(groupIndex == null ? {} : { group: groupIndex }),
+      };
+    });
 
     return {
       indexNum: index,
       createdAt: createdAt,
       tabs: blockTabs,
+      ...(groups.length <= 0 ? {} : { groups: groups }),
     };
   }
 
@@ -67,6 +104,10 @@ export namespace blockService {
       ...(block.locked === true ? { locked: true } : {}),
       // スターも同じ。付けていないブロックにキーを作らない
       ...(block.starred === true ? { starred: true } : {}),
+      // タブグループも同じ。グループを使っていないブロックにキーを作らない
+      ...(block.groups == null || block.groups.length <= 0
+        ? {}
+        : { groups: block.groups }),
     };
   }
 
@@ -118,6 +159,7 @@ export namespace blockService {
     title?: string;
     locked?: boolean;
     starred?: boolean;
+    groups?: model.TabGroup[];
     v?: number;
     d?: string;
   };
@@ -201,14 +243,101 @@ export namespace blockService {
     return starred === true ? { starred: true } : {};
   }
 
+  // chrome.tabGroups.Colorが取りうる値。知らない色をそのまま
+  // chrome.tabGroups.updateへ渡すと復元ごと失敗するため、読み込み時に弾く
+  const TAB_GROUP_COLORS: readonly string[] = [
+    'grey',
+    'blue',
+    'red',
+    'yellow',
+    'green',
+    'pink',
+    'purple',
+    'cyan',
+    'orange',
+  ];
+
+  // 色が壊れていたときの寄せ先。Chromeがグループ作成時に使う無彩色
+  const DEFAULT_TAB_GROUP_COLOR = 'grey';
+
+  /**
+   * 保存データのgroupsをタブグループの配列に変換する。
+   * titleやlockedと同じくインポートしたJSONには型の検証がないため、
+   * 配列でない・要素がオブジェクトでない場合はグループなしとして扱う
+   * @param {unknown} groups 保存データが持っていたgroups
+   * @return {object} groupsを持つオブジェクト。使っていなければ空オブジェクト
+   */
+  function blockGroupsField(groups: unknown): { groups?: model.TabGroup[] } {
+    if (!Array.isArray(groups) || groups.length <= 0) {
+      return {};
+    }
+    // 添字で参照する以上、途中の要素だけを捨てると後続の参照がずれる。
+    // 壊れた要素は既定値へ寄せて、配列の長さと並びは保つ
+    return {
+      groups: groups.map((group) => {
+        const title: unknown = (group as model.TabGroup | null)?.title;
+        const color: unknown = (group as model.TabGroup | null)?.color;
+        return {
+          ...(typeof title === 'string' && title.trim().length > 0
+            ? { title: title.trim() }
+            : {}),
+          color:
+            typeof color === 'string' && TAB_GROUP_COLORS.includes(color)
+              ? color
+              : DEFAULT_TAB_GROUP_COLOR,
+        };
+      }),
+    };
+  }
+
+  /**
+   * 保存データのタブを読む。jsonObjToBlockとjsonToBlockの両方から通す。
+   * かつてjsonToBlock側がタブを{url,title}に組み立て直しており、
+   * Tabにフィールドを足すと読み込みで消える形になっていた
+   * @param {model.Tab[]} tabs 保存データが持っていたtabs
+   * @param {model.TabGroup[] | undefined} groups 正規化済みのグループ
+   * @return {model.Tab[]} 復元したタブ
+   */
+  function toBlockTabs(
+    tabs: model.Tab[],
+    groups: model.TabGroup[] | undefined,
+  ): model.Tab[] {
+    const groupCount = groups?.length ?? 0;
+    return tabs.map((tab) => {
+      // 壊れたタブ（nullなど）はそのまま通す。作り直すと保存データの形が
+      // 変わってしまい、書き戻したときに別のデータになる
+      if (tab == null || typeof tab !== 'object') {
+        return tab;
+      }
+      const group: unknown = tab.group;
+      if (group === undefined) {
+        return tab;
+      }
+      if (
+        typeof group === 'number' &&
+        Number.isInteger(group) &&
+        group >= 0 &&
+        group < groupCount
+      ) {
+        return tab;
+      }
+      // 参照先のないグループを残すと、復元のときに存在しないグループを引く
+      const rest = { ...tab };
+      delete rest.group;
+      return rest;
+    });
+  }
+
   function jsonObjToBlock(object: BlockJson, index: number): model.Block {
+    const groupsField = blockGroupsField(object.groups);
     return {
       indexNum: index,
       createdAt: toCreatedAt(object.created_at),
-      tabs: object.tabs,
+      tabs: toBlockTabs(object.tabs, groupsField.groups),
       ...blockTitleField(object.title),
       ...blockLockedField(object.locked),
       ...blockStarredField(object.starred),
+      ...groupsField,
     };
   }
 
@@ -218,19 +347,16 @@ export namespace blockService {
 
   export function jsonToBlock(json: string, indexNum: number): model.Block {
     const js = JSON.parse(json) as BlockJson;
-
-    const tabs: model.Tab[] = js.tabs.map((jsonArr) => ({
-      url: jsonArr.url,
-      title: jsonArr.title,
-    }));
+    const groupsField = blockGroupsField(js.groups);
 
     return {
       indexNum: indexNum,
       createdAt: toCreatedAt(js.created_at),
-      tabs: tabs,
+      tabs: toBlockTabs(js.tabs, groupsField.groups),
       ...blockTitleField(js.title),
       ...blockLockedField(js.locked),
       ...blockStarredField(js.starred),
+      ...groupsField,
     };
   }
 

--- a/src/js/blockService.ts
+++ b/src/js/blockService.ts
@@ -47,11 +47,12 @@ export namespace blockService {
         continue;
       }
       groupIndexes.set(tabGroup.id, groups.length);
+      // Chromeでは名前を付けずに色だけのグループを作れる。
+      // 名前の正規化は読み込み側と同じ規則に揃える（揃えないと、
+      // 保存直後の表示と読み直したあとの表示が食い違う）
+      const groupTitle = toDisplayTitle(tabGroup.title);
       groups.push({
-        // Chromeでは名前を付けずに色だけのグループを作れる
-        ...(tabGroup.title == null || tabGroup.title.length <= 0
-          ? {}
-          : { title: tabGroup.title }),
+        ...(groupTitle == null ? {} : { title: groupTitle }),
         color: tabGroup.color,
       });
     }
@@ -104,7 +105,10 @@ export namespace blockService {
       ...(block.locked === true ? { locked: true } : {}),
       // スターも同じ。付けていないブロックにキーを作らない
       ...(block.starred === true ? { starred: true } : {}),
-      // タブグループも同じ。グループを使っていないブロックにキーを作らない
+      // タブグループも同じ。グループを使っていないブロックにキーを作らない。
+      // タブを消してどのタブからも参照されなくなったグループは、あえて
+      // 残したまま書く。詰めると後続の添字がずれ、残ったタブが別のグループを
+      // 指してしまう（使われないグループのぶん保存データは大きいままになる）
       ...(block.groups == null || block.groups.length <= 0
         ? {}
         : { groups: block.groups }),
@@ -181,7 +185,8 @@ export namespace blockService {
   }
 
   /**
-   * 保存データのtitleをブロックの名前に変換する。
+   * 保存データのtitleを表示できる名前に変換する。ブロックの名前と
+   * タブグループの名前(#191)の両方から使う。
    * 型では文字列だが、インポートしたJSONには型の検証がないため実際には
    * 何でも入りうる。文字列以外をそのままblock.titleに持たせると
    * レンダリングで例外になりブロックごと破損カードに落ちるため、
@@ -191,7 +196,7 @@ export namespace blockService {
    * @param {unknown} title 保存データが持っていたtitle
    * @return {string | undefined} ブロックの名前。名前として扱えない値ならundefined
    */
-  function toBlockTitle(title: unknown): string | undefined {
+  function toDisplayTitle(title: unknown): string | undefined {
     if (typeof title === 'string') {
       // 空文字列と空白だけの文字列は名前なしと同じ扱いにして、デフォルトの
       // タブ数表示に戻す。空白だけの名前を通すと見出しが空のカードになり、
@@ -216,7 +221,7 @@ export namespace blockService {
    * @return {object} titleを持つオブジェクト。名前がなければ空オブジェクト
    */
   function blockTitleField(title: unknown): { title?: string } {
-    const blockTitle = toBlockTitle(title);
+    const blockTitle = toDisplayTitle(title);
     return blockTitle == null ? {} : { title: blockTitle };
   }
 
@@ -277,10 +282,11 @@ export namespace blockService {
       groups: groups.map((group) => {
         const title: unknown = (group as model.TabGroup | null)?.title;
         const color: unknown = (group as model.TabGroup | null)?.color;
+        // 名前の正規化はブロック名と同じ規則に揃える。同じ復元可能な情報を
+        // フィールドによって残したり捨てたりしない
+        const groupTitle = toDisplayTitle(title);
         return {
-          ...(typeof title === 'string' && title.trim().length > 0
-            ? { title: title.trim() }
-            : {}),
+          ...(groupTitle == null ? {} : { title: groupTitle }),
           color:
             typeof color === 'string' && TAB_GROUP_COLORS.includes(color)
               ? color

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -271,7 +271,10 @@ export namespace chromeService {
         return;
       }
       // tabIdsの型は空でないタプル。空配列を渡すとChromeも例外にするため、
-      // 上で弾いたうえでタプルとして渡す
+      // 上で弾いたうえでタプルとして渡す。
+      // createPropertiesを省くとタブのあるウィンドウにグループができる。
+      // 開く側(createTabs)もwindowIdを指定していないので現在のウィンドウで
+      // 揃う。片方だけウィンドウを指すようにすると食い違う
       const groupId = await chrome.tabs.group({
         tabIds: tabIds as [number, ...number[]],
       });

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -243,10 +243,60 @@ export namespace chromeService {
   }
 
   export namespace tab {
+    /**
+     * タブを開く。
+     * 作成したタブを返すのは、タブグループの再構成(#191)にidが要るため
+     * @param {chrome.tabs.CreateProperties} properties 開くタブ
+     * @return {Promise<chrome.tabs.Tab>} 開いたタブ
+     */
     export async function createTabs(
       properties: chrome.tabs.CreateProperties,
+    ): Promise<chrome.tabs.Tab> {
+      return chrome.tabs.create(properties);
+    }
+
+    /**
+     * 保存時のタブグループを、開いたタブに対して再構成する(#191)。
+     * 名前と色まで戻すのが目的なので、グループを作るところで終わらせず
+     * tabGroups.updateまで行う
+     * @param {number[]} tabIds まとめるタブのid
+     * @param {model.TabGroup} group 復元するグループの名前と色
+     * @return {Promise<void>}
+     */
+    export async function groupTabs(
+      tabIds: number[],
+      group: model.TabGroup,
     ): Promise<void> {
-      await chrome.tabs.create(properties);
+      if (tabIds.length <= 0) {
+        return;
+      }
+      // tabIdsの型は空でないタプル。空配列を渡すとChromeも例外にするため、
+      // 上で弾いたうえでタプルとして渡す
+      const groupId = await chrome.tabs.group({
+        tabIds: tabIds as [number, ...number[]],
+      });
+      await chrome.tabGroups.update(groupId, {
+        ...(group.title == null ? {} : { title: group.title }),
+        color: group.color as chrome.tabGroups.Color,
+      });
+    }
+
+    /**
+     * ウィンドウのタブグループを取得する。
+     * グループが取れないことと、タブを保存できないことは別なので、
+     * 失敗しても例外にせず空で返す（ここでthrowするとタブごと失う）
+     * @param {number} windowId 対象のウィンドウ
+     * @return {Promise<chrome.tabGroups.TabGroup[]>} タブグループ。失敗時は空
+     */
+    export async function queryTabGroups(
+      windowId: number,
+    ): Promise<chrome.tabGroups.TabGroup[]> {
+      try {
+        return await chrome.tabGroups.query({ windowId: windowId });
+      } catch (error) {
+        console.error(error);
+        return [];
+      }
     }
 
     async function closeTab(tab: chrome.tabs.Tab): Promise<void> {

--- a/src/js/components/app.test.tsx
+++ b/src/js/components/app.test.tsx
@@ -12,6 +12,11 @@ import { model } from '../types/interface';
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+// createTabsは開いたタブを返す（タブグループの再構成にidが要る #191）。
+// テストではidだけが意味を持つので、最小限のTabを組み立てる
+const openedTab = (id = 1): chrome.tabs.Tab =>
+  ({ id: id, groupId: -1 }) as chrome.tabs.Tab;
+
 describe('App', (): void => {
   let localData: { [key: string]: string };
   let syncData: { [key: string]: string };
@@ -1256,7 +1261,7 @@ describe('App', (): void => {
       '{"v":2,"created_at":1609556645678,"tabs":[{"url":"https://example.com/a","title":"a"},null,{"url":"https://example.com/b","title":"b"}]}';
     const createTabsSpy = jest
       .spyOn(chromeService.tab, 'createTabs')
-      .mockResolvedValue(undefined);
+      .mockResolvedValue(openedTab());
     const setBlockSpy = jest
       .spyOn(chromeService.storage, 'setBlock')
       .mockResolvedValue(undefined);
@@ -1351,7 +1356,7 @@ describe('App', (): void => {
       '{"v":2,"created_at":1609556645678,"tabs":[null,{"url":"","title":"title-empty"}]}';
     const createTabsSpy = jest
       .spyOn(chromeService.tab, 'createTabs')
-      .mockResolvedValue(undefined);
+      .mockResolvedValue(openedTab());
     const setBlockSpy = jest
       .spyOn(chromeService.storage, 'setBlock')
       .mockResolvedValue(undefined);
@@ -1388,7 +1393,7 @@ describe('App', (): void => {
       '{"v":2,"created_at":1609556645678,"tabs":[{"url":"","title":"title-empty"},{"url":"https://example.com/ok","title":"title-ok"}]}';
     const createTabsSpy = jest
       .spyOn(chromeService.tab, 'createTabs')
-      .mockResolvedValue(undefined);
+      .mockResolvedValue(openedTab());
     const setBlockSpy = jest
       .spyOn(chromeService.storage, 'setBlock')
       .mockResolvedValue(undefined);
@@ -1975,8 +1980,8 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
       .mockResolvedValue(undefined);
     resolveCreateTabs = () => {};
     createTabsSpy = jest.spyOn(chromeService.tab, 'createTabs').mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolveCreateTabs = resolve;
+      new Promise<chrome.tabs.Tab>((resolve) => {
+        resolveCreateTabs = () => resolve(openedTab());
       }),
     );
     // ブロックの削除は確認を挟む(#252)。ここでの関心は書き込みの重なりなので
@@ -2046,7 +2051,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
   // ケース2: 2件の削除が重なる。ブロックを丸ごと書き戻すため、
   // 後から着地した側が相手の削除を打ち消し、消したタブが復活していた
   test('タブの削除が重なっても両方の削除が残る', async (): Promise<void> => {
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     // 1件目の書き込みを飛行中のままにして、着地する前に2件目を始めさせる
     let resolveFirstWrite: () => void = () => {};
     setBlockSpy.mockImplementationOnce(
@@ -2083,7 +2088,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
         ],
       },
     ]);
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     const resolvers: (() => void)[] = [];
     setBlockSpy.mockImplementation(
       () =>
@@ -2132,7 +2137,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
         ],
       },
     ]);
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     const resolvers: (() => void)[] = [];
     setBlockSpy.mockImplementation(
       () =>
@@ -2167,7 +2172,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
 
   // 失敗した書き込みでキューを止めると、以降そのブロックを操作できなくなる
   test('直前の書き込みが失敗しても次の書き込みは走る', async (): Promise<void> => {
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     let rejectFirstWrite: () => void = () => {};
     setBlockSpy.mockImplementationOnce(
       () =>
@@ -2192,7 +2197,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
   // 飛行中の書き込みを待たずにstorageを空にすると、あとから着地した
   // 書き込みが消したはずのブロックを書き戻し、画面が0件のまま復活する
   test('全データ削除は飛行中の書き込みが着地してから消す', async (): Promise<void> => {
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     let resolveWrite: () => void = () => {};
     setBlockSpy.mockImplementation(
       () =>
@@ -2235,7 +2240,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
   // allClearが着地するまでblocksRefは削除前のままなので、この間に始まった
   // 書き込みは「消えたブロックには書き戻さない」ガードをすり抜ける
   test('全データ削除の最中に始まった書き込みは書き戻さない', async (): Promise<void> => {
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     let resolveAllClear: () => void = () => {};
     const allClearSpy = jest
       .spyOn(chromeService.storage, 'allClear')
@@ -2290,7 +2295,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
 
     // 「すべてのリンクを開く」の書き戻しを待たせている間にtitle-aを消す
     await click('.all_tab_link');
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     await click('.tab_close', 0);
     await act(async () => {
       resolveCreateTabs();
@@ -2303,7 +2308,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
   // 壊れたブロックの削除も同じキューに乗せないと、飛行中の書き込みが
   // あとから着地して、消したブロックがstorageに戻る
   test('壊れたブロックの削除は飛行中の書き込みの後に行う', async (): Promise<void> => {
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     let resolveWrite: () => void = () => {};
     setBlockSpy.mockImplementation(
       () =>
@@ -2347,7 +2352,7 @@ describe('App ブロックへの書き込みが重なったとき', (): void => 
 
     // 2件目のリンクを開く。開き終わるまでの間に1件目を削除して並びをずらす
     await click('.tab_link', 1);
-    createTabsSpy.mockResolvedValue(undefined);
+    createTabsSpy.mockResolvedValue(openedTab());
     await click('.tab_close', 0);
     await act(async () => {
       resolveCreateTabs();

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -2312,3 +2312,187 @@ describe('Block タブグループの復元', (): void => {
     expect(groupTabsSpy).toHaveBeenCalledTimes(2);
   });
 });
+
+// 既存のブロックへ手動でリンクを足す(#253)。
+// 入力欄・検証・保存の流れは編集モーダルと同じものを使う
+describe('Block リンクの追加', (): void => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const mount = async (
+    updateBlock: UpdateBlock,
+    block?: Partial<model.Block>,
+  ): Promise<void> => {
+    renderedBlock = {
+      indexNum: 0,
+      createdAt: new Date('2021-01-02T03:04:05.678Z'),
+      tabs: [{ url: 'https://example.com/a', title: 'title-a' }],
+      ...block,
+    };
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
+    });
+  };
+
+  const clickAddTab = async (): Promise<void> => {
+    await act(async () => {
+      container.querySelector<HTMLElement>('.add_tab')!.click();
+    });
+  };
+
+  const type = async (selector: string, value: string): Promise<void> => {
+    const input = container.querySelector<HTMLInputElement>(selector)!;
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    )!.set!;
+    await act(async () => {
+      setter.call(input, value);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  };
+
+  const save = async (): Promise<void> => {
+    await act(async () => {
+      container.querySelector<HTMLElement>('.edit-tab-save')!.click();
+    });
+  };
+
+  beforeEach((): void => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      i18n: { getMessage: (key: string): string => key },
+    };
+  });
+
+  afterEach((): void => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  // spanだとキーボードのタブ順に入らず、支援技術からもボタンとして扱われない
+  test('追加の導線はボタンとして出す', async (): Promise<void> => {
+    await mount(jest.fn().mockResolvedValue(undefined));
+
+    const button = container.querySelector('.add_tab')!;
+    expect(button.tagName).toBe('BUTTON');
+    expect(button.getAttribute('type')).toBe('button');
+  });
+
+  test('空欄のモーダルが開き、追加の文言になる', async (): Promise<void> => {
+    await mount(jest.fn().mockResolvedValue(undefined));
+
+    await clickAddTab();
+
+    expect(container.querySelector('.edit-tab-modal')).not.toBeNull();
+    expect(
+      container.querySelector<HTMLInputElement>('.edit-tab-title')!.value,
+    ).toBe('');
+    expect(
+      container.querySelector<HTMLInputElement>('.edit-tab-url')!.value,
+    ).toBe('');
+    expect(container.querySelector('.uk-modal-title')!.textContent).toBe(
+      'content_msg_add_tab_heading',
+    );
+    expect(container.querySelector('.edit-tab-save')!.textContent).toBe(
+      'content_msg_add_tab_save',
+    );
+  });
+
+  test('入力して保存すると末尾に足される', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    await clickAddTab();
+    await type('.edit-tab-title', 'title-new');
+    await type('.edit-tab-url', 'https://example.com/new');
+    await save();
+
+    expect(savedBlock(updateBlock).tabs).toStrictEqual([
+      { url: 'https://example.com/a', title: 'title-a' },
+      { url: 'https://example.com/new', title: 'title-new' },
+    ]);
+    // 保存できたらモーダルは閉じる
+    expect(container.querySelector('.edit-tab-modal')).toBeNull();
+  });
+
+  // 検証は編集モーダルと同じものが効く
+  test.each([
+    ['名前が空', '', 'https://example.com/new'],
+    ['URLが不正', 'title-new', 'not a url'],
+  ])(
+    '%sなら保存せずモーダルも閉じない',
+    async (_name: string, title: string, url: string): Promise<void> => {
+      const updateBlock = jest.fn().mockResolvedValue(undefined);
+      await mount(updateBlock);
+
+      await clickAddTab();
+      await type('.edit-tab-title', title);
+      await type('.edit-tab-url', url);
+      await save();
+
+      expect(updateBlock).not.toHaveBeenCalled();
+      expect(container.querySelector('.edit-tab-modal')).not.toBeNull();
+      expect(container.querySelector('.edit-tab-error')).not.toBeNull();
+    },
+  );
+
+  test('キャンセルすると追加しない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    await clickAddTab();
+    await type('.edit-tab-title', 'title-new');
+    await type('.edit-tab-url', 'https://example.com/new');
+    await act(async () => {
+      container.querySelector<HTMLElement>('.edit-tab-cancel')!.click();
+    });
+
+    expect(updateBlock).not.toHaveBeenCalled();
+    expect(container.querySelector('.edit-tab-modal')).toBeNull();
+  });
+
+  // 保存に失敗したら入力を残したまま再試行できる状態に戻す
+  test('保存に失敗したらモーダルを閉じない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockRejectedValue(new Error('save failed'));
+    await mount(updateBlock);
+
+    await clickAddTab();
+    await type('.edit-tab-title', 'title-new');
+    await type('.edit-tab-url', 'https://example.com/new');
+    await save();
+
+    expect(container.querySelector('.edit-tab-modal')).not.toBeNull();
+    expect(
+      container.querySelector<HTMLInputElement>('.edit-tab-title')!.value,
+    ).toBe('title-new');
+  });
+
+  test('ロック中は追加できない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock, { locked: true });
+
+    await clickAddTab();
+
+    expect(container.querySelector('.edit-tab-modal')).toBeNull();
+    const button = container.querySelector('.add_tab')!;
+    expect(button.getAttribute('aria-disabled')).toBe('true');
+    expect(button.getAttribute('title')).toBe(
+      'content_msg_locked_action_disabled',
+    );
+  });
+
+  // 開いている間にタブが増減すると、後から着地した保存が打ち消し合う
+  test('追加モーダルを開いている間は背後のタブ一覧を操作できない', async (): Promise<void> => {
+    await mount(jest.fn().mockResolvedValue(undefined));
+
+    await clickAddTab();
+
+    expect(
+      container.querySelector('.uk-card-body')!.hasAttribute('inert'),
+    ).toBe(true);
+  });
+});

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -2395,7 +2395,7 @@ describe('Block リンクの追加', (): void => {
       container.querySelector<HTMLInputElement>('.edit-tab-url')!.value,
     ).toBe('');
     expect(container.querySelector('.uk-modal-title')!.textContent).toBe(
-      'content_msg_add_tab_heading',
+      'content_msg_add_tab',
     );
     expect(container.querySelector('.edit-tab-save')!.textContent).toBe(
       'content_msg_add_tab_save',
@@ -2494,5 +2494,73 @@ describe('Block リンクの追加', (): void => {
     expect(
       container.querySelector('.uk-card-body')!.hasAttribute('inert'),
     ).toBe(true);
+    // 追加ボタン自身やロック・名前編集の置き場も止める
+    expect(
+      container.querySelector('.block-card-header')!.hasAttribute('inert'),
+    ).toBe(true);
+  });
+
+  // モーダルが消えるとフォーカスがbodyまで落ちる。キーボードで開いた場合に
+  // ページ先頭からやり直しになる
+  test('閉じたら開いたボタンへフォーカスを戻す', async (): Promise<void> => {
+    await mount(jest.fn().mockResolvedValue(undefined));
+
+    await clickAddTab();
+    await act(async () => {
+      container.querySelector<HTMLElement>('.edit-tab-cancel')!.click();
+    });
+
+    expect(document.activeElement).toBe(container.querySelector('.add_tab'));
+  });
+
+  // 着地でタブが全部消えるとカードごとアンマウントされ、
+  // 入力が何の通知もなく消える
+  test('書き込みが飛行中は追加を始められない', async (): Promise<void> => {
+    const createTabsSpy = jest
+      .spyOn(chromeService.tab, 'createTabs')
+      .mockReturnValue(new Promise<chrome.tabs.Tab>(() => undefined));
+
+    try {
+      await mount(jest.fn().mockResolvedValue(undefined));
+
+      await act(async () => {
+        container.querySelectorAll<HTMLElement>('.tab_link')[0]!.click();
+      });
+
+      expect(
+        container
+          .querySelector<HTMLButtonElement>('.add_tab')!
+          .hasAttribute('disabled'),
+      ).toBe(true);
+    } finally {
+      createTabsSpy.mockRestore();
+    }
+  });
+
+  // 書きにいっても必ず弾かれるので、「保存に失敗しました」を
+  // 繰り返させず理由を出して止める
+  test('開いている間にロックされたら理由を出して保存を止める', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    await mount(updateBlock);
+
+    await clickAddTab();
+    await type('.edit-tab-title', 'title-new');
+    await type('.edit-tab-url', 'https://example.com/new');
+    // 他のページ・他端末でロックされた状態を、propsの差し替えで再現する
+    renderedBlock = { ...renderedBlock, locked: true };
+    await act(async () => {
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
+    });
+
+    expect(container.querySelector('.edit-tab-locked')).not.toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>('.edit-tab-save')!.disabled,
+    ).toBe(true);
+    await save();
+    expect(updateBlock).not.toHaveBeenCalled();
+    // 入力は残したまま。書いていた内容を自分で拾える
+    expect(
+      container.querySelector<HTMLInputElement>('.edit-tab-title')!.value,
+    ).toBe('title-new');
   });
 });

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -38,6 +38,11 @@ const savedBlock = (
 const savedIndexNum = (updateBlock: jest.Mock, callIndex = 0): number =>
   updateBlock.mock.calls[callIndex]![0] as number;
 
+// createTabsは開いたタブを返す（タブグループの再構成にidが要る #191）。
+// テストではidだけが意味を持つので、最小限のTabを組み立てる
+const openedTab = (id = 1): chrome.tabs.Tab =>
+  ({ id: id, groupId: -1 }) as chrome.tabs.Tab;
+
 describe('Block', (): void => {
   let container: HTMLDivElement;
   let root: Root;
@@ -608,8 +613,8 @@ describe('Block タブ操作と名前の編集の排他', (): void => {
     };
     resolveCreateTabs = () => {};
     createTabsSpy = jest.spyOn(chromeService.tab, 'createTabs').mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolveCreateTabs = resolve;
+      new Promise<chrome.tabs.Tab>((resolve) => {
+        resolveCreateTabs = () => resolve(openedTab());
       }),
     );
   });
@@ -771,7 +776,7 @@ describe('Block 編集のロック', (): void => {
     };
     createTabsSpy = jest
       .spyOn(chromeService.tab, 'createTabs')
-      .mockResolvedValue(undefined);
+      .mockResolvedValue(openedTab());
   });
 
   afterEach((): void => {
@@ -2076,7 +2081,7 @@ describe('Block ブロックの削除', (): void => {
   test('リンクを開いている最中でも押せる', async (): Promise<void> => {
     const createTabsSpy = jest
       .spyOn(chromeService.tab, 'createTabs')
-      .mockReturnValue(new Promise<void>(() => undefined));
+      .mockReturnValue(new Promise<chrome.tabs.Tab>(() => undefined));
 
     try {
       const updateBlock = jest.fn().mockResolvedValue(undefined);
@@ -2091,5 +2096,161 @@ describe('Block ブロックの削除', (): void => {
     } finally {
       createTabsSpy.mockRestore();
     }
+  });
+});
+
+// 保存したタブグループを「すべてのリンクを開く」で再構成する(#191)。
+// 個別のリンクではグループ化しない（1本だけのグループを作っても嬉しくない）
+describe('Block タブグループの復元', (): void => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let createTabsSpy: jest.SpyInstance;
+  let groupTabsSpy: jest.SpyInstance;
+  let errorLogSetSpy: jest.SpyInstance;
+
+  const grouped: model.Block = {
+    indexNum: 0,
+    createdAt: new Date('2021-01-02T03:04:05.678Z'),
+    tabs: [
+      { url: 'https://example.com/a', title: 'title-a', group: 0 },
+      { url: 'https://example.com/b', title: 'title-b' },
+      { url: 'https://example.com/c', title: 'title-c', group: 1 },
+      { url: 'https://example.com/d', title: 'title-d', group: 0 },
+    ],
+    groups: [
+      { title: '調査中', color: 'blue' },
+      { title: '読みもの', color: 'red' },
+    ],
+  };
+
+  const mount = async (block: model.Block = grouped): Promise<void> => {
+    renderedBlock = block;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Block
+          block={renderedBlock}
+          updateBlock={jest.fn().mockResolvedValue(undefined)}
+        />,
+      );
+    });
+  };
+
+  const click = async (selector: string, index = 0): Promise<void> => {
+    await act(async () => {
+      container.querySelectorAll<HTMLElement>(selector)[index]!.click();
+    });
+  };
+
+  beforeEach((): void => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    // 開いたタブのidは呼ばれた順に振る。どのタブがどのグループに入ったかを
+    // idで見分けられるようにする
+    let nextTabId = 100;
+    createTabsSpy = jest
+      .spyOn(chromeService.tab, 'createTabs')
+      .mockImplementation(() =>
+        Promise.resolve({ id: nextTabId++ } as chrome.tabs.Tab),
+      );
+    groupTabsSpy = jest
+      .spyOn(chromeService.tab, 'groupTabs')
+      .mockResolvedValue(undefined);
+    errorLogSetSpy = jest
+      .spyOn(chromeService.errorLog, 'set')
+      .mockResolvedValue(undefined);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      i18n: { getMessage: (key: string): string => key },
+    };
+  });
+
+  afterEach((): void => {
+    act(() => root.unmount());
+    container.remove();
+    createTabsSpy.mockRestore();
+    groupTabsSpy.mockRestore();
+    errorLogSetSpy.mockRestore();
+  });
+
+  test('すべてのリンクを開くとグループを名前と色ごと再構成する', async (): Promise<void> => {
+    await mount();
+
+    await click('.all_tab_link');
+
+    expect(groupTabsSpy).toHaveBeenCalledTimes(2);
+    // 同じグループのタブがまとまり、属していないタブは巻き込まない
+    expect(groupTabsSpy).toHaveBeenCalledWith([100, 103], {
+      title: '調査中',
+      color: 'blue',
+    });
+    expect(groupTabsSpy).toHaveBeenCalledWith([102], {
+      title: '読みもの',
+      color: 'red',
+    });
+  });
+
+  test('グループを持たないブロックではグループ化しない', async (): Promise<void> => {
+    await mount({
+      indexNum: 0,
+      createdAt: new Date('2021-01-02T03:04:05.678Z'),
+      tabs: [{ url: 'https://example.com/a', title: 'title-a' }],
+    });
+
+    await click('.all_tab_link');
+
+    expect(createTabsSpy).toHaveBeenCalledTimes(1);
+    expect(groupTabsSpy).not.toHaveBeenCalled();
+  });
+
+  // 1本だけのグループを作っても嬉しくない
+  test('個別のリンクを開いてもグループ化しない', async (): Promise<void> => {
+    await mount();
+
+    await click('.tab_link');
+
+    expect(createTabsSpy).toHaveBeenCalledTimes(1);
+    expect(groupTabsSpy).not.toHaveBeenCalled();
+  });
+
+  // タブは既に開かれているので、ここで中断すると一覧にも残って二重になる
+  test('グループ化に失敗しても書き戻しは行う', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    groupTabsSpy.mockRejectedValue(new Error('group failed'));
+    renderedBlock = grouped;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
+    });
+
+    await click('.all_tab_link');
+
+    expect(errorLogSetSpy).toHaveBeenCalled();
+    // 開いた4件すべてが一覧から消える
+    expect(savedBlock(updateBlock).tabs).toStrictEqual([]);
+  });
+
+  // 1つのグループの失敗で残りのグループまで諦めない
+  test('片方のグループ化が失敗しても他方は作る', async (): Promise<void> => {
+    groupTabsSpy.mockImplementation((tabIds: number[]) =>
+      tabIds.includes(102)
+        ? Promise.reject(new Error('group failed'))
+        : Promise.resolve(undefined),
+    );
+    await mount();
+
+    await click('.all_tab_link');
+
+    expect(groupTabsSpy).toHaveBeenCalledTimes(2);
+    expect(errorLogSetSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // ロック中は開くだけで一覧から消さないが、グループは戻す
+  test('ロック中でもグループを再構成する', async (): Promise<void> => {
+    await mount({ ...grouped, locked: true });
+
+    await click('.all_tab_link');
+
+    expect(groupTabsSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/js/components/block.test.tsx
+++ b/src/js/components/block.test.tsx
@@ -2245,6 +2245,64 @@ describe('Block タブグループの復元', (): void => {
     expect(errorLogSetSpy).toHaveBeenCalledTimes(1);
   });
 
+  // モーダルは{title,url}しか知らない。差し替えにすると、名前を直しただけで
+  // タブがグループから外れる
+  test('タブを編集してもグループから外れない', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    renderedBlock = grouped;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
+    });
+
+    await click('.tab_edit');
+    const input = container.querySelector<HTMLInputElement>('.edit-tab-title')!;
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    )!.set!;
+    await act(async () => {
+      setter.call(input, 'renamed-a');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      container.querySelector<HTMLElement>('.edit-tab-save')!.click();
+    });
+
+    expect(savedBlock(updateBlock).tabs[0]).toStrictEqual({
+      url: 'https://example.com/a',
+      title: 'renamed-a',
+      group: 0,
+    });
+  });
+
+  // 開けたタブが素のまま残ることまで巻き添えにする理由はない
+  test('1件開けなくても開けた分はグループ化する', async (): Promise<void> => {
+    const updateBlock = jest.fn().mockResolvedValue(undefined);
+    let nextTabId = 100;
+    createTabsSpy.mockImplementation((properties: { url: string }) =>
+      properties.url === 'https://example.com/d'
+        ? Promise.reject(new Error('cannot open'))
+        : Promise.resolve({ id: nextTabId++ } as chrome.tabs.Tab),
+    );
+    renderedBlock = grouped;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<Block block={renderedBlock} updateBlock={updateBlock} />);
+    });
+
+    await click('.all_tab_link');
+
+    // 開けたタブだけでグループを作る
+    expect(groupTabsSpy).toHaveBeenCalledWith([100], {
+      title: '調査中',
+      color: 'blue',
+    });
+    // 1件でも開けなかったら1本も消さない（土台からの方針）
+    expect(updateBlock).not.toHaveBeenCalled();
+    expect(errorLogSetSpy).toHaveBeenCalled();
+  });
+
   // ロック中は開くだけで一覧から消さないが、グループは戻す
   test('ロック中でもグループを再構成する', async (): Promise<void> => {
     await mount({ ...grouped, locked: true });

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -65,6 +65,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // 別のタブを指しうる。開いたタブと突き合わせて、無関係なタブを
   // 上書きしないための控え
   const [editTarget, setEditTarget] = useState<model.Tab | null>(null);
+  // 手動でタブを足すモーダルを開いているか(#253)。編集と違って
+  // 対象のタブがないので、indexも控えも持たない
+  const [addingTab, setAddingTab] = useState(false);
   // 名前の編集中かどうか。編集を始めたときの名前をdraftの初期値にする
   const [titleDraft, setTitleDraft] = useState<string | null>(null);
   const [titleSaving, setTitleSaving] = useState(false);
@@ -418,6 +421,25 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     setEditTarget(target);
   };
 
+  // 末尾に足す。既存のタブの並びは触らない
+  const saveAddedTab = (newTab: model.Tab): Promise<void> =>
+    updateTabs((current) => [...current.tabs, newTab]).then(() => {
+      setAddingTab(false);
+    });
+
+  const startTabAdd = () => {
+    // 呼び出し元の導線はロック中に塞いであるが、不変条件をUIの分岐だけに
+    // 預けると導線が増えたときに保護が黙って外れる
+    if (locked) {
+      return;
+    }
+    setAddingTab(true);
+  };
+
+  const closeTabAdd = () => {
+    setAddingTab(false);
+  };
+
   const closeTabEdit = () => {
     setEditIndex(null);
     setEditTarget(null);
@@ -525,7 +547,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // 到達できてしまう。開いている間にこのブロックのタブが増減すると、
   // 後から着地した保存が消したはずのタブを書き戻す。背後を操作不能にして塞ぐ
   // （aria-modalを名乗る以上、支援技術に対しても背後は無効であるべき）
-  const editing = editTarget != null && editIndex != null;
+  // モーダルを開いている間はカードの背後を触らせない。足すモーダルも
+  // 開いている間にタブが増減すると、後から着地した保存が打ち消し合う
+  const editing = (editTarget != null && editIndex != null) || addingTab;
   const titleEditing = titleDraft != null;
   // 名前もタブもブロックごと書き戻すため、両者が並行すると後から着地した側が
   // 相手の変更を打ち消す（名前が消える・開いたタブが一覧に戻る）。
@@ -774,6 +798,26 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
               {chrome.i18n.getMessage('content_msg_all_tab_open')}
             </span>
           </div>
+          <div className="uk-width-auto">
+            {/* 手動でリンクを足す(#253)。隣の「すべてのリンクを開く」は
+                spanのままだが、新しい導線はボタンにする。spanだと
+                キーボードのタブ順に入らず、支援技術からもボタンとして
+                扱われない。ロック中に押せないのは他の編集導線と同じで、
+                押せない理由をtitleで読ませるためフォーカスは残す */}
+            <button
+              type="button"
+              className="add_tab uk-link"
+              title={
+                locked
+                  ? chrome.i18n.getMessage('content_msg_locked_action_disabled')
+                  : undefined
+              }
+              aria-disabled={locked}
+              onClick={locked ? undefined : startTabAdd}
+            >
+              {chrome.i18n.getMessage('content_msg_add_tab')}
+            </button>
+          </div>
           <div className="uk-width-expand" />
         </div>
       </div>
@@ -822,7 +866,15 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
           )}
         </ul>
       </div>
-      {editTarget != null && editIndex != null ? (
+      {addingTab ? (
+        <EditTabModal
+          mode="add"
+          // 空欄から始める。既存のタブを指していないのでtargetLostもない
+          tab={{ url: '', title: '' }}
+          onSave={saveAddedTab}
+          onCancel={closeTabAdd}
+        />
+      ) : editTarget != null && editIndex != null ? (
         <EditTabModal
           // 編集対象が変わったときに前のタブの入力が残らないようにする
           key={editIndex}

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -424,7 +424,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // 末尾に足す。既存のタブの並びは触らない
   const saveAddedTab = (newTab: model.Tab): Promise<void> =>
     updateTabs((current) => [...current.tabs, newTab]).then(() => {
-      setAddingTab(false);
+      closeTabAdd();
     });
 
   const startTabAdd = () => {
@@ -438,6 +438,10 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
 
   const closeTabAdd = () => {
     setAddingTab(false);
+    // モーダルが消えるとフォーカスがbodyまで落ちる。キーボードで開いた
+    // 場合にページ先頭からやり直しになるため、開いたボタンへ戻す
+    // （名前の編集が閉じたときと同じ扱い）
+    addTabButton.current?.focus();
   };
 
   const closeTabEdit = () => {
@@ -508,6 +512,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
   // キーボード操作の現在位置が失われる。開いたときのボタンへ戻す
   const cardRoot = useRef<HTMLDivElement>(null);
   const titleEditButton = useRef<HTMLButtonElement>(null);
+  const addTabButton = useRef<HTMLButtonElement>(null);
   const titleWasEditing = useRef(false);
   useEffect(() => {
     if (titleWasEditing.current && titleDraft == null) {
@@ -806,6 +811,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
                 押せない理由をtitleで読ませるためフォーカスは残す */}
             <button
               type="button"
+              ref={addTabButton}
               className="add_tab uk-link"
               title={
                 locked
@@ -813,6 +819,10 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
                   : undefined
               }
               aria-disabled={locked}
+              // 書き込みが飛行中に開かせない。着地でタブが全部消えると
+              // カードごとアンマウントされ、入力が何の通知もなく消える
+              // （名前の編集ボタンと同じ扱い）
+              disabled={tabsWriting}
               onClick={locked ? undefined : startTabAdd}
             >
               {chrome.i18n.getMessage('content_msg_add_tab')}
@@ -871,6 +881,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
           mode="add"
           // 空欄から始める。既存のタブを指していないのでtargetLostもない
           tab={{ url: '', title: '' }}
+          locked={locked}
           onSave={saveAddedTab}
           onCancel={closeTabAdd}
         />
@@ -882,6 +893,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
           // 読まれないため、読み直しで入れ替わったタブを渡す意味はない
           tab={editTarget}
           targetLost={editTargetLost}
+          locked={locked}
           onSave={saveEditedTab}
           onCancel={closeTabEdit}
         />

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -269,7 +269,12 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
       if (at < 0) {
         throw new Error('edit target lost');
       }
-      return current.tabs.map((tab, i) => (i == at ? newTab : tab));
+      // モーダルは{title,url}しか知らないので、残りのフィールドは引き継ぐ。
+      // 差し替えにするとタブ側のフィールド（グループ #191）が
+      // 名前を直しただけで消える
+      return current.tabs.map((tab, i) =>
+        i == at ? { ...tab, ...newTab } : tab,
+      );
     }).then(() => {
       closeTabEdit();
     });
@@ -277,21 +282,33 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
 
   /**
    * タブをまとめて開き、保存時のタブグループを再構成する(#191)。
-   * グループ化に失敗しても解決する。タブは既に開かれているので、
-   * ここで中断すると呼び出し側が書き戻しをやめ、一覧にも残って二重になる
+   * グループ化そのものの失敗は握って解決する。タブは既に開かれているので、
+   * ここで中断すると呼び出し側が書き戻しをやめ、一覧にも残って二重になる。
+   * タブを開くのに失敗したときは、開けた分をグループ化してからrejectする。
+   * 「1件でも開けなかったら1本も消さない」のは呼び出し側の判断だが、
+   * 開けたタブが素のまま残ることまで巻き添えにする理由はない
    * @param {model.Tab[]} tabs 開くタブ
-   * @return {Promise<void>} すべて開き終わったら解決する
+   * @return {Promise<void>} 1件でも開けなかったらreject
    */
   const openTabsWithGroups = async (tabs: model.Tab[]): Promise<void> => {
-    const opened = await Promise.all(
+    const results = await Promise.allSettled(
       tabs.map((tab) =>
         chromeService.tab
           .createTabs({ url: tab.url, active: false })
           .then((created) => ({ tab: tab, id: created.id })),
       ),
     );
+    const opened = results.flatMap((result) =>
+      result.status === 'fulfilled' ? [result.value] : [],
+    );
+    const failed = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : [],
+    );
     const groups = block.groups;
     if (groups == null) {
+      if (failed.length > 0) {
+        throw failed[0];
+      }
       return;
     }
     // グループごとに開いたタブのidを集める。保存時に同じグループだった
@@ -318,6 +335,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
           .catch(console.error);
       }),
     );
+    if (failed.length > 0) {
+      throw failed[0];
+    }
   };
 
   const openAllTab = () => {

--- a/src/js/components/block.tsx
+++ b/src/js/components/block.tsx
@@ -275,6 +275,51 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     });
   };
 
+  /**
+   * タブをまとめて開き、保存時のタブグループを再構成する(#191)。
+   * グループ化に失敗しても解決する。タブは既に開かれているので、
+   * ここで中断すると呼び出し側が書き戻しをやめ、一覧にも残って二重になる
+   * @param {model.Tab[]} tabs 開くタブ
+   * @return {Promise<void>} すべて開き終わったら解決する
+   */
+  const openTabsWithGroups = async (tabs: model.Tab[]): Promise<void> => {
+    const opened = await Promise.all(
+      tabs.map((tab) =>
+        chromeService.tab
+          .createTabs({ url: tab.url, active: false })
+          .then((created) => ({ tab: tab, id: created.id })),
+      ),
+    );
+    const groups = block.groups;
+    if (groups == null) {
+      return;
+    }
+    // グループごとに開いたタブのidを集める。保存時に同じグループだった
+    // タブだけがまとまるので、グループに属していなかったタブは素のまま残る
+    const tabIdsByGroup = new Map<number, number[]>();
+    for (const { tab, id } of opened) {
+      if (tab.group == null || id == null) {
+        continue;
+      }
+      const tabIds = tabIdsByGroup.get(tab.group) ?? [];
+      tabIds.push(id);
+      tabIdsByGroup.set(tab.group, tabIds);
+    }
+    // 1つのグループの失敗で残りのグループまで諦めない
+    await Promise.all(
+      [...tabIdsByGroup].map(([groupIndex, tabIds]) => {
+        const group = groups[groupIndex];
+        if (group == null) {
+          return Promise.resolve();
+        }
+        return chromeService.tab
+          .groupTabs(tabIds, group)
+          .catch((error) => chromeService.errorLog.set(error))
+          .catch(console.error);
+      }),
+    );
+  };
+
   const openAllTab = () => {
     // 壊れたタブを踏むとmapの途中で例外になり、残りのタブが開かれないまま
     // イベントハンドラの外へ抜けて通知もされないため、開ける分だけに絞る
@@ -286,11 +331,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     }
     if (locked) {
       // ロック中は開くだけで一覧から消さない
-      Promise.all(
-        openTabs.map((tab) =>
-          chromeService.tab.createTabs({ url: tab.url, active: false }),
-        ),
-      ).catch((error) => {
+      openTabsWithGroups(openTabs).catch((error) => {
         chromeService.errorLog.set(error).catch(console.error);
       });
       return;
@@ -301,11 +342,7 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
     // 開けた分だけ消すと、失敗したタブだけが残ったのか
     // 全部残ったのかをユーザーが見分けられない
     trackTabWrite(
-      Promise.all(
-        openTabs.map((tab) =>
-          chromeService.tab.createTabs({ url: tab.url, active: false }),
-        ),
-      ).then(() => {
+      openTabsWithGroups(openTabs).then(() => {
         // 開いたタブだけを消す。開けなかったタブまでブロックごと消すと、
         // 一覧に見えていたタブが開かれもせず失われる
         removeTabs(openTabs).catch(() => {});
@@ -752,6 +789,9 @@ const Block: React.FC<BlockProps> = React.memo((props) => {
               >
                 <Tab
                   tab={tab}
+                  group={
+                    tab.group == null ? undefined : block.groups?.[tab.group]
+                  }
                   deleteClick={() => deleteClick(index)}
                   editClick={() => startTabEdit(index)}
                   openLinkClick={() => openLink(index)}

--- a/src/js/components/editTabModal.test.tsx
+++ b/src/js/components/editTabModal.test.tsx
@@ -176,7 +176,13 @@ describe('EditTabModal', (): void => {
     );
 
     await act(async () => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      // ダイアログの中で拾う。documentで拾うとモーダルが2枚開いたときに
+      // 1回のEscで両方閉じてしまう
+      container
+        .querySelector('.edit-tab-modal')!
+        .dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+        );
     });
 
     expect(onCancel).toHaveBeenCalledTimes(1);
@@ -234,7 +240,13 @@ describe('EditTabModal', (): void => {
 
     await submit();
     await act(async () => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      // ダイアログの中で拾う。documentで拾うとモーダルが2枚開いたときに
+      // 1回のEscで両方閉じてしまう
+      container
+        .querySelector('.edit-tab-modal')!
+        .dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+        );
     });
 
     expect(onSave).toHaveBeenCalledTimes(1);
@@ -288,5 +300,87 @@ describe('EditTabModal', (): void => {
     await submit();
 
     expect(onSave).toHaveBeenCalledTimes(2);
+  });
+  // aria-modalを名乗る以上、キーボードでも背後へ出られてはいけない。
+  // 出られると背後のカードの導線を操作してモーダルを重ねて開けてしまう
+  // （オーバーレイはポインタしか塞がない）
+  describe('フォーカスの閉じ込め', (): void => {
+    const focusables = (): HTMLElement[] =>
+      Array.from(
+        container.querySelectorAll<HTMLElement>(
+          '.edit-tab-modal input, .edit-tab-modal button',
+        ),
+      );
+
+    const pressTab = async (shiftKey: boolean): Promise<void> => {
+      await act(async () => {
+        container.querySelector('.edit-tab-modal')!.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: shiftKey,
+            bubbles: true,
+          }),
+        );
+      });
+    };
+
+    test('最後の要素からTabで先頭へ戻る', async (): Promise<void> => {
+      await mount(
+        { url: 'https://example.com/', title: 'old title' },
+        jest.fn().mockResolvedValue(undefined),
+        jest.fn(),
+      );
+      const all = focusables();
+      all[all.length - 1]!.focus();
+
+      await pressTab(false);
+
+      expect(document.activeElement).toBe(all[0]);
+    });
+
+    test('先頭の要素からShift+Tabで最後へ回る', async (): Promise<void> => {
+      await mount(
+        { url: 'https://example.com/', title: 'old title' },
+        jest.fn().mockResolvedValue(undefined),
+        jest.fn(),
+      );
+      const all = focusables();
+      all[0]!.focus();
+
+      await pressTab(true);
+
+      expect(document.activeElement).toBe(all[all.length - 1]);
+    });
+
+    test('途中の要素ではブラウザの既定に任せる', async (): Promise<void> => {
+      await mount(
+        { url: 'https://example.com/', title: 'old title' },
+        jest.fn().mockResolvedValue(undefined),
+        jest.fn(),
+      );
+      const all = focusables();
+      all[0]!.focus();
+
+      await pressTab(false);
+
+      // preventDefaultしないので、jsdomではフォーカスが動かない
+      expect(document.activeElement).toBe(all[0]);
+    });
+  });
+
+  // modeを省いたときに追加の文言へ倒れると、編集が「追加」に見える
+  test('modeを省くと編集の文言になる', async (): Promise<void> => {
+    await mount(
+      { url: 'https://example.com/', title: 'old title' },
+      jest.fn().mockResolvedValue(undefined),
+      jest.fn(),
+    );
+
+    expect(container.querySelector('.uk-modal-title')!.textContent).toBe(
+      'content_msg_edit_tab_heading',
+    );
+    expect(container.querySelector('.edit-tab-save')!.textContent).toBe(
+      'content_msg_edit_tab_save',
+    );
   });
 });

--- a/src/js/components/editTabModal.tsx
+++ b/src/js/components/editTabModal.tsx
@@ -131,7 +131,10 @@ export const EditTabModal: React.FC<EditTabModalProps> = (props) => {
       return;
     }
     // URLとして解釈できない文字列を弾く。スキームまでは見ないため、
-    // これを通っても開けるURLとは限らない
+    // これを通っても開けるURLとは限らない。
+    // 手入力の導線(#253)ができてchrome.tabs.createが受け付けないURLを
+    // 入れやすくなったが、許可リストで絞るとchrome://newtabのような
+    // 使い方まで奪うため、スキームは見ない方針のままとする
     if (!util.isValidUrl(newUrl)) {
       setError(chrome.i18n.getMessage('content_msg_edit_tab_url_invalid'));
       return;

--- a/src/js/components/editTabModal.tsx
+++ b/src/js/components/editTabModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useId, useState } from 'react';
+import React, { useId, useRef, useState } from 'react';
 import { model } from '../types/interface';
 import { util } from '../util';
 
@@ -16,6 +16,12 @@ interface EditTabModalProps {
    * そのまま書くと無関係なタブを上書きする
    */
   targetLost?: boolean;
+  /**
+   * 開いている間にブロックがロックされたか。
+   * trueのときは保存できない。書きにいっても必ず弾かれるので、
+   * 「保存に失敗しました」を繰り返させず理由を出して止める
+   */
+  locked?: boolean;
   // storageへの永続化が終わるまで待つ。失敗時はrejectされるため、
   // モーダルを開いたまま入力を保持して再試行できる
   onSave: (newTab: model.Tab) => Promise<void>;
@@ -58,28 +64,63 @@ export const EditTabModal: React.FC<EditTabModalProps> = (props) => {
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const adding = props.mode === 'add';
+  // 保存を止める理由。どちらも書きにいっても弾かれるので、押させない
+  const blocked = props.targetLost === true || props.locked === true;
+  const dialog = useRef<HTMLDivElement>(null);
   const headingId = useId();
   const titleFieldId = useId();
   const urlFieldId = useId();
   const onCancel = props.onCancel;
 
-  // 保存中に閉じられると、書き込みの結果を受け取る相手がいなくなる。
-  // 「キャンセルしたのに保存されていた」「後から着地した保存が次に開いた
-  // モーダルを閉じる」といった状態を作らないため、保存中はEscもキャンセルも
-  // 効かせない（storage.syncの書き込みは必ず成功か失敗で決着する）
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === 'Escape' && !saving) {
+  /**
+   * ダイアログの中のキー操作。
+   *
+   * Escapeをdocumentで拾うと、モーダルが2枚開いているときに1回のEscで
+   * 両方が閉じ、書きかけの入力まで一緒に消える。モーダルの中だけで拾う。
+   *
+   * 保存中に閉じられると、書き込みの結果を受け取る相手がいなくなる。
+   * 「キャンセルしたのに保存されていた」「後から着地した保存が次に開いた
+   * モーダルを閉じる」といった状態を作らないため、保存中はEscもキャンセルも
+   * 効かせない（storage.syncの書き込みは必ず成功か失敗で決着する）。
+   *
+   * Tabはダイアログの中で循環させる。aria-modalを名乗る以上キーボードでも
+   * 背後へ出られてはいけないし、出られると背後のカードの導線を操作して
+   * モーダルを重ねて開けてしまう（オーバーレイはポインタしか塞がない）
+   * @param {React.KeyboardEvent} event キーイベント
+   * @return {void}
+   */
+  const onKeyDown = (event: React.KeyboardEvent): void => {
+    if (event.key === 'Escape') {
+      if (!saving) {
         onCancel();
       }
-    };
-    document.addEventListener('keydown', onKeyDown);
-    return () => document.removeEventListener('keydown', onKeyDown);
-  }, [onCancel, saving]);
+      return;
+    }
+    if (event.key !== 'Tab') {
+      return;
+    }
+    const focusable = Array.from(
+      dialog.current?.querySelectorAll<HTMLElement>(
+        'input:not([disabled]), button:not([disabled])',
+      ) ?? [],
+    );
+    if (focusable.length <= 0) {
+      return;
+    }
+    const first = focusable[0]!;
+    const last = focusable[focusable.length - 1]!;
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
 
   const submit = (event: React.FormEvent): void => {
     event.preventDefault();
-    if (props.targetLost === true) {
+    if (blocked) {
       return;
     }
     const newTitle = title.trim();
@@ -112,13 +153,13 @@ export const EditTabModal: React.FC<EditTabModalProps> = (props) => {
       role="dialog"
       aria-modal="true"
       aria-labelledby={headingId}
+      ref={dialog}
+      onKeyDown={onKeyDown}
     >
       <div className="uk-modal-dialog uk-modal-body">
         <h2 className="uk-modal-title" id={headingId}>
           {chrome.i18n.getMessage(
-            adding
-              ? 'content_msg_add_tab_heading'
-              : 'content_msg_edit_tab_heading',
+            adding ? 'content_msg_add_tab' : 'content_msg_edit_tab_heading',
           )}
         </h2>
         <form onSubmit={submit}>
@@ -161,6 +202,13 @@ export const EditTabModal: React.FC<EditTabModalProps> = (props) => {
               {chrome.i18n.getMessage('content_msg_edit_tab_target_lost')}
             </p>
           ) : null}
+          {/* 開いている間にロックされた。理由を出さないと
+              「保存に失敗しました」を永久に繰り返させることになる */}
+          {props.locked === true ? (
+            <p className="uk-text-danger edit-tab-locked" role="alert">
+              {chrome.i18n.getMessage('content_msg_locked_action_disabled')}
+            </p>
+          ) : null}
           <div className="uk-text-right">
             <button
               type="button"
@@ -173,7 +221,7 @@ export const EditTabModal: React.FC<EditTabModalProps> = (props) => {
             <button
               type="submit"
               className="uk-button uk-button-primary uk-margin-small-left edit-tab-save"
-              disabled={saving || props.targetLost === true}
+              disabled={saving || blocked}
             >
               {chrome.i18n.getMessage(
                 adding

--- a/src/js/components/editTabModal.tsx
+++ b/src/js/components/editTabModal.tsx
@@ -5,6 +5,12 @@ import { util } from '../util';
 interface EditTabModalProps {
   tab: model.Tab;
   /**
+   * 既存のタブを直すのか、新しいタブを足すのか(#253)。
+   * 入力欄・検証・保存の流れは同じなので、見出しと保存ボタンの文言だけを
+   * 切り替える。省略したときは従来どおり編集として扱う
+   */
+  mode?: 'edit' | 'add';
+  /**
    * 編集を始めたタブが、外からの変更（一覧の読み直し）で入れ替わったか。
    * trueのときは保存できない。indexで指した先が別のタブになっているため、
    * そのまま書くと無関係なタブを上書きする
@@ -51,6 +57,7 @@ export const EditTabModal: React.FC<EditTabModalProps> = (props) => {
   const [url, setUrl] = useState(toInputValue(props.tab.url));
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const adding = props.mode === 'add';
   const headingId = useId();
   const titleFieldId = useId();
   const urlFieldId = useId();
@@ -108,7 +115,11 @@ export const EditTabModal: React.FC<EditTabModalProps> = (props) => {
     >
       <div className="uk-modal-dialog uk-modal-body">
         <h2 className="uk-modal-title" id={headingId}>
-          {chrome.i18n.getMessage('content_msg_edit_tab_heading')}
+          {chrome.i18n.getMessage(
+            adding
+              ? 'content_msg_add_tab_heading'
+              : 'content_msg_edit_tab_heading',
+          )}
         </h2>
         <form onSubmit={submit}>
           <div className="uk-margin">
@@ -164,7 +175,11 @@ export const EditTabModal: React.FC<EditTabModalProps> = (props) => {
               className="uk-button uk-button-primary uk-margin-small-left edit-tab-save"
               disabled={saving || props.targetLost === true}
             >
-              {chrome.i18n.getMessage('content_msg_edit_tab_save')}
+              {chrome.i18n.getMessage(
+                adding
+                  ? 'content_msg_add_tab_save'
+                  : 'content_msg_edit_tab_save',
+              )}
             </button>
           </div>
         </form>

--- a/src/js/components/tab.test.tsx
+++ b/src/js/components/tab.test.tsx
@@ -4,6 +4,7 @@
 import { act } from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { Tab } from './tab';
+import { model } from '../types/interface';
 
 // テスティングライブラリを介さず素のactを使うため必要
 (
@@ -14,12 +15,16 @@ describe('Tab', (): void => {
   let container: HTMLDivElement;
   let root: Root;
 
-  const mount = async (tab: { url: string; title: string }): Promise<void> => {
+  const mount = async (
+    tab: { url: string; title: string },
+    group?: model.TabGroup,
+  ): Promise<void> => {
     await act(async () => {
       root = createRoot(container);
       root.render(
         <Tab
           tab={tab}
+          group={group}
           deleteClick={jest.fn()}
           editClick={jest.fn()}
           openLinkClick={jest.fn()}
@@ -187,5 +192,34 @@ describe('Tab', (): void => {
     expect(link.getAttribute('href')).toBe('https://example.com/?a=1&b=2');
     expect(link.getAttribute('data-url')).toBe('https://example.com/?a=1&b=2');
     expect(link.getAttribute('data-title')).toBe('A & B');
+  });
+  // 保存時のタブグループ(#191)。「すべてのリンクを開く」で名前と色ごと
+  // 戻ることが一覧で分かるように出す
+  describe('タブグループ', (): void => {
+    const tab = { url: 'https://example.com/a', title: 'title-a' };
+
+    test('グループのないタブにはチップを出さない', async (): Promise<void> => {
+      await mount(tab);
+
+      expect(container.querySelector('.tab-group-chip')).toBeNull();
+    });
+
+    test('グループ名と色をチップで出す', async (): Promise<void> => {
+      await mount(tab, { title: '調査中', color: 'blue' });
+
+      const chip = container.querySelector('.tab-group-chip')!;
+      expect(chip.textContent).toBe('調査中');
+      // 色だけで区別させず、色は補助にとどめる
+      expect(chip.getAttribute('data-tab-group-color')).toBe('blue');
+    });
+
+    // Chromeでは名前を付けずに色だけのグループを作れる
+    test('名前のないグループはその旨を出す', async (): Promise<void> => {
+      await mount(tab, { color: 'red' });
+
+      const chip = container.querySelector('.tab-group-chip')!;
+      expect(chip.textContent).toBe('content_msg_tab_group_unnamed');
+      expect(chip.getAttribute('data-tab-group-color')).toBe('red');
+    });
   });
 });

--- a/src/js/components/tab.tsx
+++ b/src/js/components/tab.tsx
@@ -44,8 +44,10 @@ export const Tab: React.FC<TabProps> = (props) => {
           }
         >
           <span className="tab-group-dot" aria-hidden={true} />
-          {props.group.title ??
-            chrome.i18n.getMessage('content_msg_tab_group_unnamed')}
+          <span className="tab-group-name">
+            {props.group.title ??
+              chrome.i18n.getMessage('content_msg_tab_group_unnamed')}
+          </span>
         </span>
       )}
       <img

--- a/src/js/components/tab.tsx
+++ b/src/js/components/tab.tsx
@@ -4,6 +4,10 @@ import { util } from '../util';
 
 interface TabProps {
   tab: model.Tab;
+  // 保存時にこのタブが属していたタブグループ(#191)。
+  // グループに属していなかったタブと、タブグループを知らなかった頃に
+  // 保存されたタブではundefinedになる
+  group?: model.TabGroup;
   deleteClick: VoidFunction;
   editClick: VoidFunction;
   openLinkClick: VoidFunction;
@@ -27,6 +31,23 @@ export const Tab: React.FC<TabProps> = (props) => {
 
   return (
     <li className="tab-root-dom">
+      {/* 保存時のタブグループ。「すべてのリンクを開く」で名前と色ごと
+          戻ることが一覧で分かるように出す。名前を付けずに色だけの
+          グループも作れるので、名前がないときは色だけを見せる */}
+      {props.group == null ? null : (
+        <span
+          className="tab-group-chip"
+          data-tab-group-color={props.group.color}
+          title={
+            props.group.title ??
+            chrome.i18n.getMessage('content_msg_tab_group_unnamed')
+          }
+        >
+          <span className="tab-group-dot" aria-hidden={true} />
+          {props.group.title ??
+            chrome.i18n.getMessage('content_msg_tab_group_unnamed')}
+        </span>
+      )}
       <img
         src={`https://www.google.com/s2/favicons?domain=${encodeDomain}`}
         alt={props.tab.title}

--- a/src/js/types/interface.d.ts
+++ b/src/js/types/interface.d.ts
@@ -26,11 +26,35 @@ export namespace model {
      * undefinedになる
      */
     starred?: boolean;
+    /**
+     * 保存したときにタブが属していたChromeのタブグループ。
+     * タブ側はこの配列への添字(Tab.group)で参照する。名前と色をタブごとに
+     * 複製するより小さく、同じグループの実体が1つに定まる。
+     * グループを使っていないブロック（タブグループを知らなかった頃に
+     * 保存されたデータを含む）はundefinedになる
+     */
+    groups?: TabGroup[];
+  }
+
+  /**
+   * 保存したときのタブグループ。名前は付けていないことがある
+   * （Chromeでは色だけのグループを作れる）
+   */
+  interface TabGroup {
+    title?: string;
+    // chrome.tabGroups.Colorの値。知らない色が降ってきたら既定値へ寄せる
+    color: string;
   }
 
   interface Tab {
     url: string;
     title: string;
+    /**
+     * 属していたタブグループのBlock.groupsへの添字。
+     * グループに属していなかったタブと、タブグループを知らなかった頃に
+     * 保存されたタブはundefinedになる
+     */
+    group?: number;
   }
 
   /**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
   "minimum_chrome_version": "120",
   "description": "__MSG_Description__",
   "default_locale": "en",
-  "permissions": ["tabs", "storage", "contextMenus"],
+  "permissions": ["tabs", "tabGroups", "storage", "contextMenus"],
   "background": {
     "service_worker": "js/background.js"
   },


### PR DESCRIPTION
> [!NOTE]
> #267 の上に積んでいます。base は `worktree-issue-191-tab-groups`。下の PR がマージされたら base を切り替えます。

## 概要

保存済みのブロックにあとから URL を足す手段がなかった。カードの操作行に「リンクを追加」を置き、**既存の編集モーダルを流用する**。

## 変更内容

### 編集モーダルの流用

`EditTabModal` は `tab` / `onSave` / `onCancel` しか受け取っておらずブロックに依存していないため、空のタブを渡せばそのまま追加に使える。`mode?: 'edit' | 'add'` を足し、**見出しと保存ボタンの文言だけ**を切り替えた。

- 入力欄、URL の検証（`util.isValidUrl`）、名前の必須チェック、保存に失敗したら入力を残したまま再試行できる挙動 — すべて編集と共通のまま
- `targetLost`（編集対象が外からの変更で入れ替わった）は追加には無関係なので渡さない

### 導線はボタンにする

隣の「すべてのリンクを開く」は `<span class="uk-link">` のままだが、**新しく足す導線は `<button>`** にした。`span` だとキーボードのタブ順に入らず、支援技術からもボタンとして扱われない。#252 で削除導線をボタンにしたのと同じ理由。

ロック中に押せないのは他の編集導線と同じ。**`disabled` ではなく `aria-disabled`** で、押せない理由を `title` で読ませるためフォーカスは残す。

### 保存

`updateTabs((current) => [...current.tabs, newTab])` で**末尾に足す**。既存のタブの並びは触らない（タブグループの添字 `group` は並びに依存しないので影響なし）。タブを増やす操作は今まで存在しなかったが、`setBlock` はそのまま通る。

追加モーダルを開いている間も、編集と同じくカードの背後を `inert` で止める。開いている間にタブが増減すると、後から着地した保存が打ち消し合う。

### モーダルのキーボード操作

導線をボタンにしたことで、**モーダルを開いたまま他のカードの「リンクを追加」へ Tab で到達できる**ようになっていた（オーバーレイはポインタしか塞がない）。`Escape` を `document` で拾っていたため、モーダルが2枚開いていると1回の Esc で両方が閉じ、書きかけの入力まで一緒に消える。

- `Escape` を**ダイアログの中で拾う**ようにした
- `Tab` をダイアログ内で循環させた。`aria-modal` を名乗る以上、キーボードでも背後へ出られてはいけない

編集モーダルにも同じ改善が効く。

### 開いている間の状態変化

- **ロックされたとき**: 保存を押すたびに「保存に失敗しました」が出るだけで、何度試しても永久に失敗していた（しかもヘッダは `inert` でロック解除にも触れず、入力を捨てるしか出口がない）。`targetLost` と同じ形で `locked` を渡し、理由を出して保存を止める
- **書き込みが飛行中**: 追加ボタンが `tabsWriting` を見ておらず開けた。着地でタブが全部消えるとカードごとアンマウントされ、入力が何の通知もなく消える。名前の編集ボタンと同じく `disabled` にした
- **閉じたとき**: フォーカスが `body` まで落ちていた。キーボードで開いた場合にページ先頭からやり直しになるので、開いたボタンへ戻す

## 含めていないもの

**新規ブロックの作成**は含めていない（issue のタイトルには入っているが、本文の要望は「既存ブロックに手動で URL 等を登録できるようにしたい」）。`setBlock` はタブ0件のブロックを削除として扱うため、空のブロックを作るにはその不変条件を崩すか作成と同時に1件目を入れる必要があり、採番（`getNextBlockIndex`）と `setTabLength` を App 側に新設する話も出てくる。別 issue に切り出したい。

## テスト

`describe('Block リンクの追加')` を新設（13件、384 → 400件）。

- 導線が `<button type="button">` として出る
- 空欄のモーダルが開き、追加の文言（見出し・保存ボタン）になる
- 入力して保存すると**末尾**に足される / 保存できたらモーダルは閉じる
- 名前が空 / URL が不正なら保存せずモーダルも閉じない（エラーを出す）
- キャンセルすると追加しない
- 保存に失敗したらモーダルを閉じず、入力も残る
- ロック中は追加できない（`aria-disabled` と `title` も確認）
- 追加モーダルを開いている間は背後のタブ一覧を操作できない

`editTabModal.test.tsx` にも4件（フォーカスの閉じ込め3件、`mode` 省略時に編集の文言になること）。

以下の変異でテストが落ちることを確認済み: 末尾ではなく先頭に足す / ロック中でも開ける / 追加中もカード本体を操作できる / フォーカストラップを外す / `locked` で保存を止めない / `tabsWriting` を見ない / フォーカスを戻さない。

`Escape` のテストは `document` ではなくダイアログの中へ投げる形に直した（実際の経路と揃えたので、`document` で拾う実装に戻したら気付ける）。

`npx tsc --noEmit` / `npm run format:check` / `npm run lint` / `npm test`（14 suites, 400 tests）/ `npm run build` すべて通過。

## 手動確認（未実施 / レビュー時にお願いしたい点）

1. カードの「リンクを追加」→ 名前と URL を入れて保存 → 末尾に増えること
2. ロック中は押せず、ツールチップで理由が出ること
3. ボタンの見た目が隣の「すべてのリンクを開く」と揃っていること（`<button>` の既定装飾を落として `uk-link` の見た目を借りている）

## URL のスキームを見ないことについて

`util.isValidUrl` は `URL.canParse` なのでスキームを見ていない。手入力の導線ができたことで `chrome.tabs.create` が受け付けない URL（`javascript:` など）を意図せず入れやすくなる、という指摘がレビューで出た。

**スキームは見ない方針のままとする**（`http` に限定したくないため）。`chrome://newtab` のような使い方を許可リストで奪うほうが損失が大きい。判断は `editTabModal.tsx` のコメントにも残した。

なお、開けない URL が1件混ざると、#191 の「1件でも開けなかったら1本も消さない」方針と噛み合って、そのブロックの「すべてのリンクを開く」が押すたびにタブを重複させ続ける。これはスキーマ検証とは別の論点（既存の編集導線でも起こせる）なので、必要なら別 issue にしたい。

Closes #253
Refs #252
Refs #191
