### PR TITLE
@eslint/jsをeslint本体とメジャーを揃える

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "react-dom": "^19.2.8"
       },
       "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.5",
         "@types/chrome": "^0.2.6",
         "@types/jest": "^30.0.0",
         "@types/node": "^26.2.0",
@@ -883,24 +883,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -4430,19 +4422,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "SyncTabClipper",
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.5",
     "@types/chrome": "^0.2.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^26.2.0",


### PR DESCRIPTION
## 概要

`@eslint/js` が 10 系なのに `eslint` は 9 系のままで、**npm が新規解決を拒否する状態**になっていました。

```
npm error Conflicting peer dependency: eslint@10.9.0
npm error   peerOptional eslint@"^10.0.0" from @eslint/js@10.0.1
npm error   node_modules/@eslint/js
```

`package-lock.json` には両方が同居しているので `npm ci`（＝ CI）は通ります。そのため今まで気付かれず、**依存を1つでも足し引きしようとしたときだけ表面化**します（#237 で不要になった `buffer` を消そうとして踏みました）。

## どちらへ揃えるか

`eslint` を 10 へ上げる側では揃えられません。`eslint-plugin-react@7.37.5` の peer は eslint 10 に未対応のためです。

| パッケージ | peer eslint |
|---|---|
| `eslint-plugin-react@7.37.5` | `^3 \|\| ... \|\| ^9.7` ← **10 未対応** |
| `typescript-eslint@8.67.0` | `^8.57.0 \|\| ^9.0.0 \|\| ^10.0.0` |
| `eslint-config-prettier@10.1.8` | `>=7.0.0` |

したがって `@eslint/js` を **9.39.5**（`eslint` 本体と同じ版）へ戻します。dependabot の #238（eslint 10.8.1）は、`eslint-plugin-react` が対応するまで保留するのが筋です。

## 影響

`eslint.config.mjs` は `js.configs.recommended` しか使っておらず、9 系で挙動は変わりません。

`node_modules` を消して**ロック通りに `npm ci` し直したうえで**、`npm run format:check` / `npm run lint` / `npx tsc --noEmit` / `npx jest`（14 suites, 347 tests）が通ることを確認しています。

```
@eslint/js: 9.39.5
eslint:     9.39.5
```

これで `npm install` / `npm uninstall` が普通に通るようになります。

## 関連

- #237 / #272 — `buffer` が不要になったが、この不整合のせいで消せなかった。**この PR がマージされたあと #272 側で消します**（master ではまだ `zlib-wrapper.ts` が `buffer` を使っているので、先に消すとビルドが壊れます）
- #238 — eslint 10 への更新。`eslint-plugin-react` の対応待ち
