### PR TITLE
コンテキストメニューを作り直す前に前回分を消す

### DIFF
--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -45,8 +45,7 @@ async function saveWindowTabs(windowId: number): Promise<void> {
 }
 
 chrome.runtime.onInstalled.addListener(() => {
-  chromeService.ContextMenus.createParentMenu();
-  chromeService.ContextMenus.createGotoTabsPageMenu();
+  chromeService.ContextMenus.recreateMenus().catch(handleError);
 });
 
 chrome.contextMenus.onClicked.addListener((info) => {

--- a/src/js/chromeService.test.ts
+++ b/src/js/chromeService.test.ts
@@ -777,3 +777,86 @@ describe('chromeService.storage.isBlockDataKey', (): void => {
     expect(chromeService.storage.isBlockDataKey(key)).toBe(expected);
   });
 });
+
+describe('chromeService.ContextMenus.recreateMenus', (): void => {
+  // Chromeが拡張ごとに保持しているメニューを、idをキーに再現する
+  let registered: Map<string | number, chrome.contextMenus.CreateProperties>;
+  let calls: string[];
+
+  beforeEach((): void => {
+    registered = new Map();
+    calls = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).chrome = {
+      runtime: {
+        getManifest: () => ({ name: 'SyncTabClipper', version: '9.9.9' }),
+        lastError: undefined,
+      },
+      i18n: { getMessage: (key: string): string => key },
+      contextMenus: {
+        removeAll: (): Promise<void> => {
+          calls.push('removeAll');
+          registered.clear();
+          return Promise.resolve();
+        },
+        create: (
+          props: chrome.contextMenus.CreateProperties,
+          callback: () => void,
+        ): void => {
+          calls.push(`create:${String(props.id)}`);
+          if (props.id != null && registered.has(props.id)) {
+            // 実物はlastErrorをセットしたうえでcallbackを呼ぶ
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const runtime = chrome.runtime as any;
+            runtime.lastError = {
+              message: `Cannot create item with duplicate id ${String(props.id)}`,
+            };
+            callback();
+            runtime.lastError = undefined;
+            return;
+          }
+          if (props.id != null) {
+            registered.set(props.id, props);
+          }
+          callback();
+        },
+      },
+    };
+  });
+
+  test('親メニューとtabsページを開くメニューを登録する', async (): Promise<void> => {
+    await chromeService.ContextMenus.recreateMenus();
+
+    expect(calls).toEqual([
+      'removeAll',
+      'create:SyncTabClipper.mainMenu',
+      'create:gotoTabsPage',
+    ]);
+    expect(registered.get('gotoTabsPage')?.parentId).toBe(
+      'SyncTabClipper.mainMenu',
+    );
+  });
+
+  test('前回分のメニューが残っていても重複エラーにならない', async (): Promise<void> => {
+    // 拡張の更新や再読み込みでonInstalledが再発火した状況
+    await chromeService.ContextMenus.recreateMenus();
+    calls = [];
+
+    await expect(
+      chromeService.ContextMenus.recreateMenus(),
+    ).resolves.toBeUndefined();
+    expect(calls[0]).toBe('removeAll');
+    expect(registered.size).toBe(2);
+  });
+
+  test('createが失敗したときはlastErrorの内容で失敗する', async (): Promise<void> => {
+    // removeAllが効かなかった場合でも、エラーがUnchecked runtime.lastErrorとして
+    // 握りつぶされずに呼び出し側へ届く
+    chrome.contextMenus.removeAll = (): Promise<void> => Promise.resolve();
+    registered.set('SyncTabClipper.mainMenu', {});
+
+    await expect(chromeService.ContextMenus.recreateMenus()).rejects.toThrow(
+      'Cannot create item with duplicate id SyncTabClipper.mainMenu',
+    );
+  });
+});

--- a/src/js/chromeService.ts
+++ b/src/js/chromeService.ts
@@ -420,17 +420,43 @@ export namespace chromeService {
     const parentMenuId = () => `${appName()}.mainMenu`;
     export const gotoTabsPageMenuId = 'gotoTabsPage';
 
-    export function createParentMenu(): void {
-      chrome.contextMenus.create({
+    /**
+     * contextMenus.createをPromiseに包む。createはPromiseを返さず、
+     * 失敗はcallback内のruntime.lastErrorでしか分からないため、
+     * 見に行かないと「Unchecked runtime.lastError」として握りつぶされる
+     * @param {chrome.contextMenus.CreateProperties} props 登録するメニュー
+     * @return {Promise<void>}
+     */
+    function create(
+      props: chrome.contextMenus.CreateProperties,
+    ): Promise<void> {
+      return new Promise((resolve, reject) => {
+        chrome.contextMenus.create(props, () => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+            return;
+          }
+          resolve();
+        });
+      });
+    }
+
+    /**
+     * コンテキストメニューを作り直す。
+     * メニューはChromeが拡張ごとに永続化しているため、更新や再読み込みで
+     * onInstalledが再び発火したときに前回分が残っている。そのまま作ると
+     * 「Cannot create item with duplicate id」になるので、いったん全消しする
+     * @return {Promise<void>}
+     */
+    export async function recreateMenus(): Promise<void> {
+      await chrome.contextMenus.removeAll();
+      await create({
         id: parentMenuId(),
         title: appName(),
         type: 'normal',
         contexts: ['all'],
       });
-    }
-
-    export function createGotoTabsPageMenu(): void {
-      chrome.contextMenus.create({
+      await create({
         id: gotoTabsPageMenuId,
         title: chrome.i18n.getMessage('content_msg_open_tab_page'),
         parentId: parentMenuId(),


### PR DESCRIPTION
## 問題

拡張の更新・再読み込み後、service worker のコンソールに以下が出ていた。

```
Unchecked runtime.lastError: Cannot create item with duplicate id SyncTabClipper.mainMenu
Unchecked runtime.lastError: Cannot create item with duplicate id gotoTabsPage
```

## 原因

`chrome.runtime.onInstalled` はインストール時だけでなく更新・再読み込みでも発火する。一方コンテキストメニューは Chrome が拡張ごとに永続化しているため、前回登録分が残った状態で同じ id を `create` して重複エラーになっていた。`create` は Promise を返さず callback 内の `runtime.lastError` でしか失敗が分からないため、見に行っていない分が「Unchecked runtime.lastError」として出ていた。

## 修正

- `ContextMenus.recreateMenus()` に統合し、`contextMenus.removeAll()` してから親メニュー・子メニューを登録する
- `create` を Promise に包み、`lastError` を reject として `handleError` へ流す
- テスト追加：初回登録、前回分が残っている場合の再登録、`create` 失敗時の伝播

## 確認

- `npx jest` 362 passed / `npm run lint` / `npx tsc --noEmit` / webpack dev ビルド すべて通過
- 実機での「拡張を再読み込みしてもエラーが出ない」確認は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)